### PR TITLE
Add netstandard2.0 target

### DIFF
--- a/BasicTest/BasicTest.csproj
+++ b/BasicTest/BasicTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>StackExchange.Redis.BasicTest .NET Core</Description>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>BasicTest</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>BasicTest</PackageId>
@@ -16,6 +16,10 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <DefineConstants>$(DefineConstants);CORE_CLR</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <DefineConstants>$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/BasicTest/BasicTest.csproj
+++ b/BasicTest/BasicTest.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <DefineConstants>$(DefineConstants);CORE_CLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD1</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -22,7 +22,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <IncludeSymbols>false</IncludeSymbols>
 
-    <LibraryTargetFrameworks>net45;net46;netstandard1.5</LibraryTargetFrameworks>
+    <LibraryTargetFrameworks>net45;net46;netstandard1.5;netstandard2.0</LibraryTargetFrameworks>
     <CoreFxVersion>4.3.0</CoreFxVersion>
     <xUnitVersion>2.3.0-beta5-build3750</xUnitVersion>
   </PropertyGroup>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -24,6 +24,6 @@
 
     <LibraryTargetFrameworks>net45;net46;netstandard1.5;netstandard2.0</LibraryTargetFrameworks>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <xUnitVersion>2.3.0-beta5-build3750</xUnitVersion>
+    <xUnitVersion>2.3.1</xUnitVersion>
   </PropertyGroup>
 </Project>

--- a/NRediSearch.Test/NRediSearch.Test.csproj
+++ b/NRediSearch.Test/NRediSearch.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/StackExchange.Redis.StrongName/StackExchange.Redis.StrongName.csproj
+++ b/StackExchange.Redis.StrongName/StackExchange.Redis.StrongName.csproj
@@ -22,11 +22,15 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46'">
-    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZATION;FEATURE_SOCKET_MODE_POLL</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZATION;FEATURE_SOCKET_MODE_POLL;FEATURE_PERFCOUNTER;FEATURE_THREADPOOL</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <DefineConstants>$(DefineConstants);CORE_CLR</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZATION;FEATURE_THREADPOOL</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
@@ -39,4 +43,10 @@
     <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Threading.ThreadPool" Version="$(CoreFxVersion)" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="$(CoreFxVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/StackExchange.Redis.StrongName/StackExchange.Redis.StrongName.csproj
+++ b/StackExchange.Redis.StrongName/StackExchange.Redis.StrongName.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <DefineConstants>$(DefineConstants);CORE_CLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD1</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/StackExchange.Redis.Tests/BasicOps.cs
+++ b/StackExchange.Redis.Tests/BasicOps.cs
@@ -231,12 +231,12 @@ namespace StackExchange.Redis.Tests
                 RedisKey key = "MBOA";
                 var conn = muxer.GetDatabase();
                 await conn.PingAsync().ForAwait();
-#if CORE_CLR
+#if NETSTANDARD1
                 int number = 0;
 #endif
                 Action<Task> nonTrivial = delegate
                 {
-#if !CORE_CLR
+#if !NETSTANDARD1
                     Thread.SpinWait(5);
 #else
                     for (int i = 0; i < 50; i++)

--- a/StackExchange.Redis.Tests/Booksleeve/Config.cs
+++ b/StackExchange.Redis.Tests/Booksleeve/Config.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
-#if !CORE_CLR
+#if !NETSTANDARD1
 using System.Security.Authentication;
 #endif
 
@@ -106,7 +106,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
             }
         }
 
-#if !CORE_CLR
+#if !NETSTANDARD1
         [Fact]
         public void SslProtocols_SingleValue()
         {

--- a/StackExchange.Redis.Tests/Config.cs
+++ b/StackExchange.Redis.Tests/Config.cs
@@ -161,7 +161,7 @@ namespace StackExchange.Redis.Tests
                 var all = conn.ConfigGet();
                 Assert.True(all.Length > 0, "any");
 
-#if !CORE_CLR
+#if !NETSTANDARD1
                 var pairs = all.ToDictionary(x => (string)x.Key, x => (string)x.Value, StringComparer.InvariantCultureIgnoreCase);
 #else
                 var pairs = all.ToDictionary(x => (string)x.Key, x => (string)x.Value, StringComparer.OrdinalIgnoreCase);

--- a/StackExchange.Redis.Tests/Helpers/TestConfig.cs
+++ b/StackExchange.Redis.Tests/Helpers/TestConfig.cs
@@ -2,7 +2,7 @@
 using Jil;
 using System;
 using System.Collections.Generic;
-#if CORE_CLR
+#if NETSTANDARD1
 using System.Reflection;
 #endif
 

--- a/StackExchange.Redis.Tests/Naming.cs
+++ b/StackExchange.Redis.Tests/Naming.cs
@@ -168,7 +168,7 @@ namespace StackExchange.Redis.Tests
                 Type[] args = pFrom.Select(x => x.ParameterType).ToArray();
                 Output.WriteLine("Checking: {0}.{1}", from.Name, method.Name);
                 Assert.Equal(typeof(CommandFlags), args.Last());
-#if !CORE_CLR
+#if !NETSTANDARD1
                 var found = to.GetMethod(huntName, flags, null, method.CallingConvention, args, null);
 #else
                 var found = to.GetMethods(flags)
@@ -192,14 +192,14 @@ namespace StackExchange.Redis.Tests
         private void CheckMethod(MethodInfo method, bool isAsync)
         {
 #if DEBUG
-#if !CORE_CLR
+#if !NETSTANDARD1
             bool ignorePrefix = ignoreType != null && Attribute.IsDefined(method, ignoreType);
 #else
             bool ignorePrefix = ignoreType != null && method.IsDefined(ignoreType);
 #endif
             if (ignorePrefix)
             {
-#if !CORE_CLR
+#if !NETSTANDARD1
                 Attribute attrib = Attribute.GetCustomAttribute(method, ignoreType);
 #else
                 Attribute attrib = method.GetCustomAttribute(ignoreType);
@@ -253,7 +253,7 @@ namespace StackExchange.Redis.Tests
 
     public static class ReflectionExtensions
     {
-#if !CORE_CLR
+#if !NETSTANDARD1
         public static Type GetTypeInfo(this Type type)
         {
             return type;

--- a/StackExchange.Redis.Tests/Profiling.cs
+++ b/StackExchange.Redis.Tests/Profiling.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-#if CORE_CLR
+#if NETSTANDARD1
 using System.Reflection;
 #endif
 using System.Threading.Tasks;

--- a/StackExchange.Redis.Tests/PubSub.cs
+++ b/StackExchange.Redis.Tests/PubSub.cs
@@ -293,7 +293,7 @@ namespace StackExchange.Redis.Tests
     {
         public static int Read(ref int location)
         {
-#if !CORE_CLR
+#if !NETSTANDARD1
             return Thread.VolatileRead(ref location);
 #else
             return Volatile.Read(ref location);

--- a/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>StackExchange.Redis.Tests</Description>
-    <TargetFrameworks>net462;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>StackExchange.Redis.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -18,6 +18,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <DefineConstants>$(DefineConstants);FEATURE_MOQ;CORE_CLR</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <DefineConstants>$(DefineConstants);FEATURE_MOQ</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -17,7 +17,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_MOQ</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <DefineConstants>$(DefineConstants);FEATURE_MOQ;CORE_CLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_MOQ;NETSTANDARD1</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);FEATURE_MOQ</DefineConstants>

--- a/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -25,8 +25,6 @@
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
-    <!-- Temp workaround for analyzer issue -->
-    <PackageReference Include="xunit.analyzers" Version="0.6.1" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />

--- a/StackExchange.Redis.Tests/TestBase.cs
+++ b/StackExchange.Redis.Tests/TestBase.cs
@@ -62,7 +62,7 @@ namespace StackExchange.Redis.Tests
             {
                 Console.WriteLine("Unobserved: " + args.Exception);
                 args.SetObserved();
-#if CORE_CLR
+#if NETSTANDARD1
                 if (IgnorableExceptionPredicates.Any(predicate => predicate(args.Exception.InnerException))) return;
 #endif
                 Interlocked.Increment(ref sharedFailCount);
@@ -73,7 +73,7 @@ namespace StackExchange.Redis.Tests
             };
         }
 
-#if CORE_CLR
+#if NETSTANDARD1
         private static readonly Func<Exception, bool>[] IgnorableExceptionPredicates = new Func<Exception, bool>[]
         {
             e => e != null && e is ObjectDisposedException && e.Message.Equals("Cannot access a disposed object.\r\nObject name: 'System.Net.Sockets.NetworkStream'."),
@@ -326,7 +326,7 @@ namespace StackExchange.Redis.Tests
             }
             if (!allDone.WaitOne(timeout))
             {
-#if !CORE_CLR
+#if !NETSTANDARD1
                 for (int i = 0; i < threads; i++)
                 {
                     var thd = threadArr[i];

--- a/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/StackExchange.Redis/StackExchange.Redis.csproj
@@ -17,11 +17,15 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46'">
-    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZATION;FEATURE_SOCKET_MODE_POLL</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZATION;FEATURE_SOCKET_MODE_POLL;FEATURE_PERFCOUNTER;FEATURE_THREADPOOL</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <DefineConstants>$(DefineConstants);CORE_CLR</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZATION;FEATURE_THREADPOOL</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
@@ -34,4 +38,10 @@
     <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Threading.ThreadPool" Version="$(CoreFxVersion)" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="$(CoreFxVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/StackExchange.Redis/StackExchange.Redis.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <DefineConstants>$(DefineConstants);CORE_CLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD1</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/StackExchange.Redis/StackExchange/Redis/Compat/ConvertHelper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Compat/ConvertHelper.cs
@@ -17,7 +17,7 @@ namespace StackExchange.Redis
         /// <returns></returns>
         public static TOutput[] ConvertAll<TInput, TOutput>(TInput[] source, Func<TInput, TOutput> selector)
         {
-#if CORE_CLR
+#if NETSTANDARD1
             TOutput[] arr = new TOutput[source.Length];
             for(int i = 0 ; i < arr.Length ; i++)
                 arr[i] = selector(source[i]);

--- a/StackExchange.Redis/StackExchange/Redis/Compat/VolatileWrapper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Compat/VolatileWrapper.cs
@@ -4,7 +4,7 @@
     {
         public static int Read(ref int location)
         {
-#if !CORE_CLR
+#if !NETSTANDARD1
             return System.Threading.Thread.VolatileRead(ref location);
 #else
             return System.Threading.Volatile.Read(ref location);
@@ -13,7 +13,7 @@
 
         public static void Write(ref int address, int value)
         {
-#if !CORE_CLR
+#if !NETSTANDARD1
             System.Threading.Thread.VolatileWrite(ref address, value);
 #else
             System.Threading.Volatile.Write(ref address, value);

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -31,7 +31,7 @@ namespace StackExchange.Redis
     /// The options relevant to a set of redis connections
     /// </summary>
     public sealed class ConfigurationOptions
-#if !CORE_CLR
+#if !NETSTANDARD1
         : ICloneable
 #endif
     {
@@ -160,7 +160,7 @@ namespace StackExchange.Redis
         /// Indicates whether the connection should be encrypted
         /// </summary>
         [Obsolete("Please use .Ssl instead of .UseSsl"),
-#if !CORE_CLR
+#if !NETSTANDARD1
             Browsable(false),
 #endif
             EditorBrowsable(EditorBrowsableState.Never)]
@@ -379,7 +379,7 @@ namespace StackExchange.Redis
                 responseTimeout = responseTimeout,
                 defaultDatabase = defaultDatabase,
                 ReconnectRetryPolicy = reconnectRetryPolicy,
-#if !CORE_CLR
+#if !NETSTANDARD1
                 SslProtocols = SslProtocols,
 #endif
             };
@@ -516,7 +516,7 @@ namespace StackExchange.Redis
             }
         }
 
-#if !CORE_CLR
+#if !NETSTANDARD1
         static bool IsOption(string option, string prefix)
         {
             return option.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase);
@@ -538,7 +538,7 @@ namespace StackExchange.Redis
             SocketManager = null;
         }
 
-#if !CORE_CLR
+#if !NETSTANDARD1
         object ICloneable.Clone() { return Clone(); }
 #endif
 
@@ -640,7 +640,7 @@ namespace StackExchange.Redis
                         case OptionKeys.DefaultDatabase:
                             defaultDatabase = OptionKeys.ParseInt32(key, value);
                             break;
-#if !CORE_CLR
+#if !NETSTANDARD1
                         case OptionKeys.SslProtocols:
                             SslProtocols = OptionKeys.ParseSslProtocols(key, value);
                             break;

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -108,7 +108,7 @@ namespace StackExchange.Redis
         {
             string roleInstanceId = null;
             // TODO: CoreCLR port pending https://github.com/dotnet/coreclr/issues/919
-#if !CORE_CLR
+#if !NETSTANDARD1
             try
             {
                 Assembly asm = null;

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -605,7 +605,7 @@ namespace StackExchange.Redis
             return false;
         }
 
-#if !CORE_CLR
+#if FEATURE_THREADPOOL
         private void LogLockedWithThreadPoolStats(TextWriter log, string message, out int busyWorkerCount)
         {
             busyWorkerCount = 0;
@@ -647,7 +647,7 @@ namespace StackExchange.Redis
             }
 
             var watch = Stopwatch.StartNew();
-#if !CORE_CLR
+#if FEATURE_THREADPOOL
             int busyWorkerCount;
             LogLockedWithThreadPoolStats(log, "Awaiting task completion", out busyWorkerCount);
 #endif
@@ -657,7 +657,7 @@ namespace StackExchange.Redis
                 var remaining = timeoutMilliseconds - checked((int)watch.ElapsedMilliseconds);
                 if (remaining <= 0)
                 {
-#if !CORE_CLR
+#if FEATURE_THREADPOOL
                     LogLockedWithThreadPoolStats(log, "Timeout before awaiting for tasks", out busyWorkerCount);
 #endif
                     return false;
@@ -666,7 +666,7 @@ namespace StackExchange.Redis
                 var allTasks = Task.WhenAll(tasks).ObserveErrors();
                 var any = Task.WhenAny(allTasks, Task.Delay(remaining)).ObserveErrors();
                 bool all = await any.ForAwait() == allTasks;
-#if !CORE_CLR
+#if FEATURE_THREADPOOL
                 LogLockedWithThreadPoolStats(log, all ? "All tasks completed cleanly" : "Not all tasks completed cleanly", out busyWorkerCount);
 #endif
                 return all;
@@ -684,7 +684,7 @@ namespace StackExchange.Redis
                     var remaining = timeoutMilliseconds - checked((int)watch.ElapsedMilliseconds);
                     if (remaining <= 0)
                     {
-#if !CORE_CLR
+#if FEATURE_THREADPOOL
                         LogLockedWithThreadPoolStats(log, "Timeout awaiting tasks", out busyWorkerCount);
 #endif
                         return false;
@@ -697,7 +697,7 @@ namespace StackExchange.Redis
                     { }
                 }
             }
-#if !CORE_CLR
+#if FEATURE_THREADPOOL
             LogLockedWithThreadPoolStats(log, "Finished awaiting tasks", out busyWorkerCount);
 #endif
             return false;
@@ -2065,13 +2065,14 @@ namespace StackExchange.Redis
                             {
                                 add("Key-HashSlot", "keyHashSlot", message.GetHashSlot(this.ServerSelectionStrategy).ToString());
                             }
-#if !CORE_CLR
+#if FEATURE_THREADPOOL
                             string iocp, worker;
                             int busyWorkerCount = GetThreadPoolStats(out iocp, out worker);
                             add("ThreadPool-IO-Completion", "IOCP", iocp);
                             add("ThreadPool-Workers", "WORKER", worker);
                             data.Add(Tuple.Create("Busy-Workers", busyWorkerCount.ToString()));
-
+#endif
+#if FEATURE_PERFCOUNTER
                             if (IncludePerformanceCountersInExceptions)
                             {
                                 add("Local-CPU", "Local-CPU", GetSystemCpuPercent());
@@ -2112,7 +2113,7 @@ namespace StackExchange.Redis
             }
         }
 
-#if !CORE_CLR
+#if FEATURE_PERFCOUNTER
         internal static string GetThreadPoolAndCPUSummary(bool includePerformanceCounters)
         {
             string iocp, worker;
@@ -2130,7 +2131,8 @@ namespace StackExchange.Redis
             }
             return "unavailable";
         }
-
+#endif
+#if FEATURE_THREADPOOL
         private static int GetThreadPoolStats(out string iocp, out string worker)
         {
             //BusyThreads =  TP.GetMaxThreads() –TP.GetAVailable();

--- a/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
+++ b/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
@@ -285,7 +285,7 @@ namespace StackExchange.Redis
         /// </summary>
         Async = 2
     }
-#if !CORE_CLR
+#if FEATURE_PERFCOUNTER
 
     internal static class PerfCounterHelper
     {
@@ -332,8 +332,9 @@ namespace StackExchange.Redis
             return false;
         }
     }
-
-    internal static class CompletionTypeHelper
+#endif
+#if FEATURE_THREADPOOL
+    internal class CompletionTypeHelper
     {
         public static void RunWithCompletionType(Func<AsyncCallback, IAsyncResult> beginAsync, AsyncCallback callback, CompletionType completionType)
         {

--- a/StackExchange.Redis/StackExchange/Redis/ExceptionFactory.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ExceptionFactory.cs
@@ -127,7 +127,7 @@ namespace StackExchange.Redis
                 exceptionmessage.Append("; ").Append(innermostExceptionstring);
             }
 
-#if !CORE_CLR
+#if FEATURE_PERFCOUNTER
             if (includeDetail)
             {
                 exceptionmessage.Append("; ").Append(ConnectionMultiplexer.GetThreadPoolAndCPUSummary(includePerformanceCounters));

--- a/StackExchange.Redis/StackExchange/Redis/ExtensionMethods.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ExtensionMethods.cs
@@ -137,7 +137,7 @@ namespace StackExchange.Redis
 
             var certificateCollection = new X509CertificateCollection();
             const bool checkCertRevocation = true;
-#if CORE_CLR
+#if NETSTANDARD1
             ssl.AuthenticateAsClientAsync(host, certificateCollection, allowedProtocols.Value, checkCertRevocation)
                                 .GetAwaiter().GetResult();
 #else
@@ -147,7 +147,7 @@ namespace StackExchange.Redis
 
         private static void AuthenticateAsClientUsingDefaultProtocols(SslStream ssl, string host)
         {
-#if CORE_CLR
+#if NETSTANDARD1
             ssl.AuthenticateAsClientAsync(host).GetAwaiter().GetResult();
 #else
             ssl.AuthenticateAsClient(host);

--- a/StackExchange.Redis/StackExchange/Redis/HashEntry.cs
+++ b/StackExchange.Redis/StackExchange/Redis/HashEntry.cs
@@ -32,7 +32,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The name of the hash field
         /// </summary>
-#if !CORE_CLR
+#if !NETSTANDARD1
         [Browsable(false)]
 #endif
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Please use Name", false)]

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -10,7 +10,7 @@ using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
-#if CORE_CLR
+#if NETSTANDARD1
 using System.Threading.Tasks;
 #endif
 
@@ -26,7 +26,7 @@ namespace StackExchange.Redis
 
         private static readonly byte[] Crlf = Encoding.ASCII.GetBytes("\r\n");
 
-#if CORE_CLR
+#if NETSTANDARD1
         readonly Action<Task<int>> endRead;
         private static Action<Task<int>> EndReadFactory(PhysicalConnection physical)
         {
@@ -110,7 +110,7 @@ namespace StackExchange.Redis
             var endpoint = bridge.ServerEndPoint.EndPoint;
             physicalName = connectionType + "#" + Interlocked.Increment(ref totalCount) + "@" + Format.ToString(endpoint);
             this.Bridge = bridge;
-#if CORE_CLR
+#if NETSTANDARD1
             endRead = EndReadFactory(this);
 #endif
             OnCreateEcho();
@@ -147,7 +147,7 @@ namespace StackExchange.Redis
             if (outStream != null)
             {
                 Multiplexer.Trace("Disconnecting...", physicalName);
-#if !CORE_CLR
+#if !NETSTANDARD1
                 try { outStream.Close(); } catch { }
 #endif
                 try { outStream.Dispose(); } catch { }
@@ -155,7 +155,7 @@ namespace StackExchange.Redis
             }
             if (netStream != null)
             {
-#if !CORE_CLR
+#if !NETSTANDARD1
                 try { netStream.Close(); } catch { }
 #endif
                 try { netStream.Dispose(); } catch { }
@@ -639,7 +639,7 @@ namespace StackExchange.Redis
             }
             else
             {
-#if !CORE_CLR
+#if !NETSTANDARD1
                 fixed (char* c = value)
                 fixed (byte* b = outScratch)
                 {
@@ -713,7 +713,7 @@ namespace StackExchange.Redis
                     keepReading = false;
                     int space = EnsureSpaceAndComputeBytesToRead();
                     Multiplexer.Trace("Beginning async read...", physicalName);
-#if CORE_CLR
+#if NETSTANDARD1
                     var result = netStream.ReadAsync(ioBuffer, ioBufferBytes, space);
                     switch (result.Status)
                     {
@@ -736,7 +736,7 @@ namespace StackExchange.Redis
 #endif
                 } while (keepReading);
             }
-#if CORE_CLR
+#if NETSTANDARD1
             catch (AggregateException ex)
             {
                 throw ex.InnerException;
@@ -835,7 +835,7 @@ namespace StackExchange.Redis
             }
         }
 
-#if CORE_CLR
+#if NETSTANDARD1
         private bool EndReading(Task<int> result)
         {
             try

--- a/StackExchange.Redis/StackExchange/Redis/RedisValue.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisValue.cs
@@ -1,5 +1,5 @@
 using System;
-#if CORE_CLR
+#if NETSTANDARD1
 using System.Collections.Generic;
 using System.Reflection;
 #endif
@@ -301,7 +301,7 @@ namespace StackExchange.Redis
                     if (otherType == CompareType.Double) return thisDouble.CompareTo(otherDouble);
                 }
                 // otherwise, compare as strings
-#if !CORE_CLR
+#if !NETSTANDARD1
                 return StringComparer.InvariantCulture.Compare((string)this, (string)other);
 #else
                 var compareInfo = System.Globalization.CultureInfo.InvariantCulture.CompareInfo;
@@ -682,7 +682,7 @@ namespace StackExchange.Redis
 
     internal static class ReflectionExtensions
     {
-#if CORE_CLR
+#if NETSTANDARD1
         internal static TypeCode GetTypeCode(this Type type)
         {
             if (type == null) return TypeCode.Empty;

--- a/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
@@ -176,7 +176,7 @@ namespace StackExchange.Redis
                             else
                             {
                                 err = string.Format("Endpoint {0} serving hashslot {1} is not reachable at this point of time. Please check connectTimeout value. If it is low, try increasing it to give the ConnectionMultiplexer a chance to recover from the network disconnect.  ", endpoint, hashSlot);
-#if !CORE_CLR
+#if FEATURE_PERFCOUNTER
                                 err += ConnectionMultiplexer.GetThreadPoolAndCPUSummary(bridge.Multiplexer.IncludePerformanceCountersInExceptions);
 #endif
                             }

--- a/StackExchange.Redis/StackExchange/Redis/ScriptParameterMapper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ScriptParameterMapper.cs
@@ -313,7 +313,7 @@ namespace StackExchange.Redis
             LocalBuilder redisKeyLoc = null;
             var loc = il.DeclareLocal(t);
             il.Emit(OpCodes.Ldarg_0);               // object
-#if !CORE_CLR
+#if !NETSTANDARD1
             if (t.IsValueType)
 #else
             if (t.GetTypeInfo().IsValueType)
@@ -348,7 +348,7 @@ namespace StackExchange.Redis
             {
                 il.Emit(OpCodes.Dup);                       // RedisKey[] RedisKey[]
                 il.Emit(OpCodes.Ldc_I4, i);                 // RedisKey[] RedisKey[] int
-#if !CORE_CLR
+#if !NETSTANDARD1
                 if (t.IsValueType)
 #else
                 if (t.GetTypeInfo().IsValueType)
@@ -380,7 +380,7 @@ namespace StackExchange.Redis
             {
                 il.Emit(OpCodes.Dup);                       // RedisKey[] RedisValue[] RedisValue[]
                 il.Emit(OpCodes.Ldc_I4, i);                 // RedisKey[] RedisValue[] RedisValue[] int
-#if !CORE_CLR
+#if !NETSTANDARD1
                 if (t.IsValueType)
 #else
                 if (t.GetTypeInfo().IsValueType)

--- a/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
@@ -190,7 +190,7 @@ namespace StackExchange.Redis
                     // A work-around for a Mono bug in BeginConnect(EndPoint endpoint, AsyncCallback callback, object state)
                     DnsEndPoint dnsEndpoint = (DnsEndPoint)endpoint;
 
-#if CORE_CLR
+#if !FEATURE_THREADPOOL
                     multiplexer.LogLocked(log, "BeginConnect: {0}", formattedEndpoint);
                     socket.ConnectAsync(dnsEndpoint.Host, dnsEndpoint.Port).ContinueWith(t =>
                     {
@@ -214,7 +214,7 @@ namespace StackExchange.Redis
                 }
                 else
                 {
-#if CORE_CLR
+#if !FEATURE_THREADPOOL
                     multiplexer.LogLocked(log, "BeginConnect: {0}", formattedEndpoint);
                     socket.ConnectAsync(endpoint).ContinueWith(t =>
                     {

--- a/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
-#if CORE_CLR
+#if NETSTANDARD1
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 #endif
@@ -136,7 +136,7 @@ namespace StackExchange.Redis
 
             // we need a dedicated writer, because when under heavy ambient load
             // (a busy asp.net site, for example), workers are not reliable enough
-#if !CORE_CLR
+#if !NETSTANDARD1
             Thread dedicatedWriter = new Thread(writeAllQueues, 32 * 1024); // don't need a huge stack;
             dedicatedWriter.Priority = useHighPrioritySocketThreads ? ThreadPriority.AboveNormal : ThreadPriority.Normal;
 #else
@@ -254,7 +254,7 @@ namespace StackExchange.Redis
             // or will be subject to WFP filtering.
             const int SIO_LOOPBACK_FAST_PATH = -1744830448;
 
-#if !CORE_CLR
+#if !NETSTANDARD1
             // windows only
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
@@ -322,7 +322,7 @@ namespace StackExchange.Redis
                 if (ignoreConnect) return;
                 var socket = tuple.Item1;
                 var callback = tuple.Item2;
-#if CORE_CLR
+#if NETSTANDARD1
                 multiplexer.Wait((Task)ar); // make it explode if invalid (note: already complete at this point)
 #else
                 socket.EndConnect(ar);
@@ -393,7 +393,7 @@ namespace StackExchange.Redis
             {
                 OnShutdown(socket);
                 try { socket.Shutdown(SocketShutdown.Both); } catch { }
-#if !CORE_CLR
+#if !NETSTANDARD1
                 try { socket.Close(); } catch { }
 #endif
                 try { socket.Dispose(); } catch { }

--- a/StackExchange.Redis/StackExchange/Redis/SortedSetEntry.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SortedSetEntry.cs
@@ -37,7 +37,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The score against the element
         /// </summary>
-#if !CORE_CLR
+#if !NETSTANDARD1
         [Browsable(false)]
 #endif
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Please use Score", false)]
@@ -46,7 +46,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The unique element stored in the sorted set
         /// </summary>
-#if !CORE_CLR
+#if !NETSTANDARD1
         [Browsable(false)]
 #endif
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Please use Element", false)]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,15 @@ nuget:
 build_script:
 - ps: .\build.ps1 -BuildNumber "$env:APPVEYOR_BUILD_NUMBER" -Version "$env:APPVEYOR_REPO_TAG_NAME" -PullRequestNumber "$env:APPVEYOR_PULL_REQUEST_NUMBER" -CreatePackages $true
 
+before_build:
+- cmd: >-
+    "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\gacutil.exe" -l System.Runtime.Extensions
+
+    dotnet build
+
+- ps: Get-ChildItem -Recurse .\StackExchange.Redis.Tests\bin\Debug\netcoreapp1.0\*.json | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+- ps: Get-ChildItem StackExchange.Redis.Tests\obj\*.json | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+
 test: off
 artifacts:
 - path: .\.nupkgs\*.nupkg


### PR DESCRIPTION
**Add netstandard2.0 target to SE.Redis projects**

Two new conditional compilation constants are introduced:

* FEATURE_PERFCOUNTER - supported in net45 and net46
* FEATURE_THREADPOOL - supported in net45, net46, and netstandard2.0

CORE_CLR is renamed to NETSTANDARD1

NETSTANDARD1 is not defined for netstandard2.0 target

**Upgrade xunit to 2.3.1**
After upgrade, the build is warning about xunit.analyzers package downgrade to
0.6.1. Fixing by remove the explicit 0.6.1 reference.

**Add netcoreapp2.0 target framework to test projects**
