### PR TITLE
http -> https for links in codebase. (#735)

### DIFF
--- a/StackExchange.Redis.Tests/Booksleeve/Hashes.cs
+++ b/StackExchange.Redis.Tests/Booksleeve/Hashes.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests.Booksleeve
 {
-    public class Hashes : BookSleeveTestBase // http://redis.io/commands#hash
+    public class Hashes : BookSleeveTestBase // https://redis.io/commands#hash
     {
         public Hashes(ITestOutputHelper output) : base(output) { }
 
@@ -166,7 +166,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestSet() // http://redis.io/commands/hset
+        public void TestSet() // https://redis.io/commands/hset
         {
             using (var muxer = GetUnsecuredConnection())
             {
@@ -204,7 +204,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestSetNotExists() // http://redis.io/commands/hsetnx
+        public void TestSetNotExists() // https://redis.io/commands/hsetnx
         {
             using (var muxer = GetUnsecuredConnection())
             {
@@ -234,7 +234,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestDelSingle() // http://redis.io/commands/hdel
+        public void TestDelSingle() // https://redis.io/commands/hdel
         {
             using (var muxer = GetUnsecuredConnection())
             {
@@ -254,7 +254,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestDelMulti() // http://redis.io/commands/hdel
+        public void TestDelMulti() // https://redis.io/commands/hdel
         {
             using (var muxer = GetUnsecuredConnection())
             {
@@ -291,7 +291,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestDelMultiInsideTransaction() // http://redis.io/commands/hdel
+        public void TestDelMultiInsideTransaction() // https://redis.io/commands/hdel
         {
             using (var outer = GetUnsecuredConnection())
             {
@@ -327,7 +327,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestExists() // http://redis.io/commands/hexists
+        public void TestExists() // https://redis.io/commands/hexists
         {
             using (var muxer = GetUnsecuredConnection())
             {
@@ -346,7 +346,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestHashKeys() // http://redis.io/commands/hkeys
+        public void TestHashKeys() // https://redis.io/commands/hkeys
         {
             using (var muxer = GetUnsecuredConnection())
             {
@@ -370,7 +370,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestHashValues() // http://redis.io/commands/hvals
+        public void TestHashValues() // https://redis.io/commands/hvals
         {
             using (var muxer = GetUnsecuredConnection())
             {
@@ -394,7 +394,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestHashLength() // http://redis.io/commands/hlen
+        public void TestHashLength() // https://redis.io/commands/hlen
         {
             using (var muxer = GetUnsecuredConnection())
             {
@@ -414,7 +414,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestGetMulti() // http://redis.io/commands/hmget
+        public void TestGetMulti() // https://redis.io/commands/hmget
         {
             using (var muxer = GetUnsecuredConnection())
             {
@@ -453,7 +453,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestGetPairs() // http://redis.io/commands/hgetall
+        public void TestGetPairs() // https://redis.io/commands/hgetall
         {
             using (var muxer = GetUnsecuredConnection())
             {
@@ -476,7 +476,7 @@ namespace StackExchange.Redis.Tests.Booksleeve
         }
 
         [Fact]
-        public void TestSetPairs() // http://redis.io/commands/hmset
+        public void TestSetPairs() // https://redis.io/commands/hmset
         {
             using (var muxer = GetUnsecuredConnection())
             {

--- a/StackExchange.Redis.Tests/Booksleeve/PubSub.cs
+++ b/StackExchange.Redis.Tests/Booksleeve/PubSub.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests.Booksleeve
 {
-    public class PubSub : BookSleeveTestBase // http://redis.io/commands#pubsub
+    public class PubSub : BookSleeveTestBase // https://redis.io/commands#pubsub
     {
         public PubSub(ITestOutputHelper output) : base(output) { }
 

--- a/StackExchange.Redis.Tests/Booksleeve/Strings.cs
+++ b/StackExchange.Redis.Tests/Booksleeve/Strings.cs
@@ -5,7 +5,7 @@ using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests.Booksleeve
 {
-    public class Strings : BookSleeveTestBase // http://redis.io/commands#string
+    public class Strings : BookSleeveTestBase // https://redis.io/commands#string
     {
         public Strings(ITestOutputHelper output) : base(output) { }
 

--- a/StackExchange.Redis/StackExchange/Redis/Bitwise.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Bitwise.cs
@@ -1,24 +1,24 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// <a href="http://en.wikipedia.org/wiki/Bitwise_operation">Bitwise operators</a>
+    /// <a href="https://en.wikipedia.org/wiki/Bitwise_operation">Bitwise operators</a>
     /// </summary>
     public enum Bitwise
     {
         /// <summary>
-        /// <a href="http://en.wikipedia.org/wiki/Bitwise_operation#AND">And</a>
+        /// <a href="https://en.wikipedia.org/wiki/Bitwise_operation#AND">And</a>
         /// </summary>
         And,
         /// <summary>
-        /// <a href="http://en.wikipedia.org/wiki/Bitwise_operation#OR">Or</a>
+        /// <a href="https://en.wikipedia.org/wiki/Bitwise_operation#OR">Or</a>
         /// </summary>
         Or,
         /// <summary>
-        /// <a href="http://en.wikipedia.org/wiki/Bitwise_operation#XOR">Xor</a>
+        /// <a href="https://en.wikipedia.org/wiki/Bitwise_operation#XOR">Xor</a>
         /// </summary>
         Xor,
         /// <summary>
-        /// <a href="http://en.wikipedia.org/wiki/Bitwise_operation#NOT">Not</a>
+        /// <a href="https://en.wikipedia.org/wiki/Bitwise_operation#NOT">Not</a>
         /// </summary>
         Not
     }

--- a/StackExchange.Redis/StackExchange/Redis/ClusterConfiguration.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ClusterConfiguration.cs
@@ -302,7 +302,7 @@ namespace StackExchange.Redis
         internal ClusterNode() { }
         internal ClusterNode(ClusterConfiguration configuration, string raw, EndPoint origin)
         {
-            // http://redis.io/commands/cluster-nodes
+            // https://redis.io/commands/cluster-nodes
             this.configuration = configuration;
             this.Raw = raw;
             var parts = raw.Split(StringSplits.Space);

--- a/StackExchange.Redis/StackExchange/Redis/CommandMap.cs
+++ b/StackExchange.Redis/StackExchange/Redis/CommandMap.cs
@@ -68,11 +68,11 @@ namespace StackExchange.Redis
         }, true);
 
         /// <summary>
-        /// The commands available to <a href="Sentinel">http://redis.io/topics/sentinel</a>
+        /// The commands available to <a href="Sentinel">https://redis.io/topics/sentinel</a>
         /// </summary>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         public static CommandMap Sentinel { get; } = Create(new HashSet<string> {
-            // see http://redis.io/topics/sentinel
+            // see https://redis.io/topics/sentinel
             "ping", "info", "sentinel", "subscribe", "psubscribe", "unsubscribe", "punsubscribe" }, true);
 
         /// <summary>

--- a/StackExchange.Redis/StackExchange/Redis/CommandTrace.cs
+++ b/StackExchange.Redis/StackExchange/Redis/CommandTrace.cs
@@ -48,7 +48,7 @@ namespace StackExchange.Redis
         {
             if (Arguments == null || Arguments.Length == 0) return null;
 
-            const string BaseUrl = "http://redis.io/commands/";
+            const string BaseUrl = "https://redis.io/commands/";
 
             string encoded0 = Uri.EscapeUriString(((string)Arguments[0]).ToLowerInvariant());
 

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -48,7 +48,7 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed partial class ConnectionMultiplexer : IConnectionMultiplexer, IDisposable
     {
-        private static readonly string timeoutHelpLink = "http://stackexchange.github.io/StackExchange.Redis/Timeouts";
+        private static readonly string timeoutHelpLink = "https://stackexchange.github.io/StackExchange.Redis/Timeouts";
 
         private static TaskFactory _factory = null;
 

--- a/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
+++ b/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
@@ -25,14 +25,14 @@ namespace StackExchange.Redis
         /// Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <returns>the value of key, or nil when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/get</remarks>
+        /// <remarks>https://redis.io/commands/get</remarks>
         RedisValue StringGet(int db, RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <returns>the value of key, or nil when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/get</remarks>
+        /// <remarks>https://redis.io/commands/get</remarks>
         Task<RedisValue> StringGetAsync(int db, RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -43,13 +43,13 @@ namespace StackExchange.Redis
         /// <summary>
         /// DEBUG SEGFAULT performs an invalid memory access that crashes Redis. It is used to simulate bugs during the development.
         /// </summary>
-        /// <remarks>http://redis.io/commands/debug-segfault</remarks>
+        /// <remarks>https://redis.io/commands/debug-segfault</remarks>
         void Crash();
 
         /// <summary>
         /// CLIENT PAUSE is a connections control command able to suspend all the Redis clients for the specified amount of time (in milliseconds).
         /// </summary>
-        /// <remarks>http://redis.io/commands/client-pause</remarks>
+        /// <remarks>https://redis.io/commands/client-pause</remarks>
         void Hang(TimeSpan duration, CommandFlags flags = CommandFlags.None);
     }
 
@@ -58,14 +58,14 @@ namespace StackExchange.Redis
         /// <summary>
         /// The CLIENT GETNAME returns the name of the current connection as set by CLIENT SETNAME. Since every new connection starts without an associated name, if no name was assigned a null string is returned.
         /// </summary>
-        /// <remarks>http://redis.io/commands/client-getname</remarks>
+        /// <remarks>https://redis.io/commands/client-getname</remarks>
         /// <returns>The connection name, or a null string if no name is set.</returns>
         string ClientGetName(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Ask the server to close the connection. The connection is closed as soon as all pending replies have been written to the client.
         /// </summary>
-        /// <remarks>http://redis.io/commands/quit</remarks>
+        /// <remarks>https://redis.io/commands/quit</remarks>
         void Quit(CommandFlags flags = CommandFlags.None);
     }
 
@@ -74,7 +74,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The CLIENT GETNAME returns the name of the current connection as set by CLIENT SETNAME. Since every new connection starts without an associated name, if no name was assigned a null string is returned.
         /// </summary>
-        /// <remarks>http://redis.io/commands/client-getname</remarks>
+        /// <remarks>https://redis.io/commands/client-getname</remarks>
         /// <returns>The connection name, or a null string if no name is set.</returns>
         Task<string> ClientGetNameAsync(CommandFlags flags = CommandFlags.None);
     }

--- a/StackExchange.Redis/StackExchange/Redis/IDatabaseAsync.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IDatabaseAsync.cs
@@ -13,14 +13,14 @@ namespace StackExchange.Redis
         /// <summary>
         /// Returns the raw DEBUG OBJECT output for a key; this command is not fully documented and should be avoided unless you have good reason, and then avoided anyway.
         /// </summary>
-        /// <remarks>http://redis.io/commands/debug-object</remarks>
+        /// <remarks>https://redis.io/commands/debug-object</remarks>
         Task<RedisValue> DebugObjectAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Add the specified member to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <returns>True if the specified member was not already present in the set, else False</returns>
-        /// <remarks>http://redis.io/commands/geoadd</remarks>
+        /// <remarks>https://redis.io/commands/geoadd</remarks>
         Task<bool> GeoAddAsync(RedisKey key, double longitude, double latitude, RedisValue member, CommandFlags flags = CommandFlags.None);
 
 
@@ -28,7 +28,7 @@ namespace StackExchange.Redis
         /// Add the specified member to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <returns>True if the specified member was not already present in the set, else False</returns>
-        /// <remarks>http://redis.io/commands/geoadd</remarks>
+        /// <remarks>https://redis.io/commands/geoadd</remarks>
         Task<bool> GeoAddAsync(RedisKey key, StackExchange.Redis.GeoEntry value, CommandFlags flags = CommandFlags.None);
 
 
@@ -36,35 +36,35 @@ namespace StackExchange.Redis
         /// Add the specified members to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <returns>the number of elements that were added to the set, not including all the elements already present into the set.</returns>
-        /// <remarks>http://redis.io/commands/geoadd</remarks>
+        /// <remarks>https://redis.io/commands/geoadd</remarks>
         Task<long> GeoAddAsync(RedisKey key, GeoEntry[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes the specified member from the geo sorted set stored at key. Non existing members are ignored.
         /// </summary>
         /// <returns>True if the member existed in the sorted set and was removed; False otherwise.</returns>
-        /// <remarks>http://redis.io/commands/zrem</remarks>
+        /// <remarks>https://redis.io/commands/zrem</remarks>
         Task<bool> GeoRemoveAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the distance between two members in the geospatial index represented by the sorted set.
         /// </summary>
         /// <returns>The command returns the distance as a double (represented as a string) in the specified unit, or NULL if one or both the elements are missing.</returns>
-        /// <remarks>http://redis.io/commands/geodist</remarks>
+        /// <remarks>https://redis.io/commands/geodist</remarks>
         Task<double?> GeoDistanceAsync(RedisKey key, RedisValue member1, RedisValue member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return valid Geohash strings representing the position of one or more elements in a sorted set value representing a geospatial index (where elements were added using GEOADD).
         /// </summary>
         /// <returns>The command returns an array where each element is the Geohash corresponding to each member name passed as argument to the command.</returns>
-        /// <remarks>http://redis.io/commands/geohash</remarks>
+        /// <remarks>https://redis.io/commands/geohash</remarks>
         Task<string[]> GeoHashAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return valid Geohash strings representing the position of one or more elements in a sorted set value representing a geospatial index (where elements were added using GEOADD).
         /// </summary>
         /// <returns>The command returns an array where each element is the Geohash corresponding to each member name passed as argument to the command.</returns>
-        /// <remarks>http://redis.io/commands/geohash</remarks>
+        /// <remarks>https://redis.io/commands/geohash</remarks>
         Task<string> GeoHashAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
 
@@ -72,28 +72,28 @@ namespace StackExchange.Redis
         /// Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the sorted set at key.
         /// </summary>
         /// <returns>The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.Non existing elements are reported as NULL elements of the array.</returns>
-        /// <remarks>http://redis.io/commands/geopos</remarks>
+        /// <remarks>https://redis.io/commands/geopos</remarks>
         Task<GeoPosition?[]> GeoPositionAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the sorted set at key.
         /// </summary>
         /// <returns>The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.Non existing elements are reported as NULL elements of the array.</returns>
-        /// <remarks>http://redis.io/commands/geopos</remarks>
+        /// <remarks>https://redis.io/commands/geopos</remarks>
         Task<GeoPosition?> GeoPositionAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the members of a sorted set populated with geospatial information using GEOADD, which are within the borders of the area specified with the center location and the maximum distance from the center (the radius).
         /// </summary>
         /// <returns>GeoRadiusResult[]</returns>
-        /// <remarks>http://redis.io/commands/georadius</remarks>
+        /// <remarks>https://redis.io/commands/georadius</remarks>
         Task<GeoRadiusResult[]> GeoRadiusAsync(RedisKey key, RedisValue member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the members of a sorted set populated with geospatial information using GEOADD, which are within the borders of the area specified with the center location and the maximum distance from the center (the radius).
         /// </summary>
         /// <returns>GeoRadiusResult[]</returns>
-        /// <remarks>http://redis.io/commands/georadius</remarks>
+        /// <remarks>https://redis.io/commands/georadius</remarks>
         Task<GeoRadiusResult[]> GeoRadiusAsync(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
 
@@ -102,7 +102,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <remarks>The range of values supported by HINCRBY is limited to 64 bit signed integers.</remarks>
         /// <returns>the value at field after the increment operation.</returns>
-        /// <remarks>http://redis.io/commands/hincrby</remarks>
+        /// <remarks>https://redis.io/commands/hincrby</remarks>
         Task<long> HashDecrementAsync(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -110,20 +110,20 @@ namespace StackExchange.Redis
         /// </summary>
         /// <remarks>The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.</remarks>
         /// <returns>the value at field after the decrement operation.</returns>
-        /// <remarks>http://redis.io/commands/hincrbyfloat</remarks>
+        /// <remarks>https://redis.io/commands/hincrbyfloat</remarks>
         Task<double> HashDecrementAsync(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes the specified fields from the hash stored at key. Non-existing fields are ignored. Non-existing keys are treated as empty hashes and this command returns 0.
         /// </summary>
-        /// <remarks>http://redis.io/commands/hdel</remarks>
+        /// <remarks>https://redis.io/commands/hdel</remarks>
         /// <returns>The number of fields that were removed.</returns>
         Task<bool> HashDeleteAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes the specified fields from the hash stored at key. Non-existing fields are ignored. Non-existing keys are treated as empty hashes and this command returns 0.
         /// </summary>
-        /// <remarks>http://redis.io/commands/hdel</remarks>
+        /// <remarks>https://redis.io/commands/hdel</remarks>
         /// <returns>The number of fields that were removed.</returns>
         Task<long> HashDeleteAsync(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None);
 
@@ -131,21 +131,21 @@ namespace StackExchange.Redis
         /// Returns if field is an existing field in the hash stored at key.
         /// </summary>
         /// <returns>1 if the hash contains field. 0 if the hash does not contain field, or key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/hexists</remarks>
+        /// <remarks>https://redis.io/commands/hexists</remarks>
         Task<bool> HashExistsAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns all fields and values of the hash stored at key. 
         /// </summary>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/hgetall</remarks>
+        /// <remarks>https://redis.io/commands/hgetall</remarks>
         Task<HashEntry[]> HashGetAllAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the value associated with field in the hash stored at key.
         /// </summary>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/hget</remarks>
+        /// <remarks>https://redis.io/commands/hget</remarks>
         Task<RedisValue> HashGetAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace StackExchange.Redis
         /// For every field that does not exist in the hash, a nil value is returned.Because a non-existing keys are treated as empty hashes, running HMGET against a non-existing key will return a list of nil values.
         /// </summary>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
-        /// <remarks>http://redis.io/commands/hmget</remarks>
+        /// <remarks>https://redis.io/commands/hmget</remarks>
         Task<RedisValue[]> HashGetAsync(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <remarks>The range of values supported by HINCRBY is limited to 64 bit signed integers.</remarks>
         /// <returns>the value at field after the increment operation.</returns>
-        /// <remarks>http://redis.io/commands/hincrby</remarks>
+        /// <remarks>https://redis.io/commands/hincrby</remarks>
         Task<long> HashIncrementAsync(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -169,82 +169,82 @@ namespace StackExchange.Redis
         /// </summary>
         /// <remarks>The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.</remarks>
         /// <returns>the value at field after the increment operation.</returns>
-        /// <remarks>http://redis.io/commands/hincrbyfloat</remarks>
+        /// <remarks>https://redis.io/commands/hincrbyfloat</remarks>
         Task<double> HashIncrementAsync(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns all field names in the hash stored at key.
         /// </summary>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/hkeys</remarks>
+        /// <remarks>https://redis.io/commands/hkeys</remarks>
         Task<RedisValue[]> HashKeysAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the number of fields contained in the hash stored at key.
         /// </summary>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/hlen</remarks>
+        /// <remarks>https://redis.io/commands/hlen</remarks>
         Task<long> HashLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Sets the specified fields to their respective values in the hash stored at key. This command overwrites any existing fields in the hash. If key does not exist, a new key holding a hash is created.
         /// </summary>
-        /// <remarks>http://redis.io/commands/hmset</remarks>
+        /// <remarks>https://redis.io/commands/hmset</remarks>
         Task HashSetAsync(RedisKey key, HashEntry[] hashFields, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
         /// </summary>
         /// <returns>1 if field is a new field in the hash and value was set. 0 if field already exists in the hash and the value was updated.</returns>
-        /// <remarks>http://redis.io/commands/hset</remarks>
-        /// <remarks>http://redis.io/commands/hsetnx</remarks>
+        /// <remarks>https://redis.io/commands/hset</remarks>
+        /// <remarks>https://redis.io/commands/hsetnx</remarks>
         Task<bool> HashSetAsync(RedisKey key, RedisValue hashField, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns all values in the hash stored at key.
         /// </summary>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/hvals</remarks>
+        /// <remarks>https://redis.io/commands/hvals</remarks>
         Task<RedisValue[]> HashValuesAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Adds the element to the HyperLogLog data structure stored at the variable name specified as first argument.
         /// </summary>
         /// <returns>true if at least 1 HyperLogLog internal register was altered. false otherwise.</returns>
-        /// <remarks>http://redis.io/commands/pfadd</remarks>
+        /// <remarks>https://redis.io/commands/pfadd</remarks>
         Task<bool> HyperLogLogAddAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Adds all the element arguments to the HyperLogLog data structure stored at the variable name specified as first argument.
         /// </summary>
         /// <returns>true if at least 1 HyperLogLog internal register was altered. false otherwise.</returns>
-        /// <remarks>http://redis.io/commands/pfadd</remarks>
+        /// <remarks>https://redis.io/commands/pfadd</remarks>
         Task<bool> HyperLogLogAddAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the approximated cardinality computed by the HyperLogLog data structure stored at the specified variable, or 0 if the variable does not exist.
         /// </summary>
         /// <returns>The approximated number of unique elements observed via HyperLogLogAdd.</returns>
-        /// <remarks>http://redis.io/commands/pfcount</remarks>
+        /// <remarks>https://redis.io/commands/pfcount</remarks>
         Task<long> HyperLogLogLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the approximated cardinality of the union of the HyperLogLogs passed, by internally merging the HyperLogLogs stored at the provided keys into a temporary hyperLogLog, or 0 if the variable does not exist.
         /// </summary>
         /// <returns>The approximated number of unique elements observed via HyperLogLogAdd.</returns>
-        /// <remarks>http://redis.io/commands/pfcount</remarks>
+        /// <remarks>https://redis.io/commands/pfcount</remarks>
         Task<long> HyperLogLogLengthAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Merge multiple HyperLogLog values into an unique value that will approximate the cardinality of the union of the observed Sets of the source HyperLogLog structures.
         /// </summary>
-        /// <remarks>http://redis.io/commands/pfmerge</remarks>
+        /// <remarks>https://redis.io/commands/pfmerge</remarks>
         Task HyperLogLogMergeAsync(RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Merge multiple HyperLogLog values into an unique value that will approximate the cardinality of the union of the observed Sets of the source HyperLogLog structures.
         /// </summary>
-        /// <remarks>http://redis.io/commands/pfmerge</remarks>
+        /// <remarks>https://redis.io/commands/pfmerge</remarks>
         Task HyperLogLogMergeAsync(RedisKey destination, RedisKey[] sourceKeys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -264,28 +264,28 @@ namespace StackExchange.Redis
         /// Removes the specified key. A key is ignored if it does not exist.
         /// </summary>
         /// <returns>True if the key was removed.</returns>
-        /// <remarks>http://redis.io/commands/del</remarks>
+        /// <remarks>https://redis.io/commands/del</remarks>
         Task<bool> KeyDeleteAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes the specified keys. A key is ignored if it does not exist.
         /// </summary>
         /// <returns>The number of keys that were removed.</returns>
-        /// <remarks>http://redis.io/commands/del</remarks>
+        /// <remarks>https://redis.io/commands/del</remarks>
         Task<long> KeyDeleteAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Serialize the value stored at key in a Redis-specific format and return it to the user. The returned value can be synthesized back into a Redis key using the RESTORE command.
         /// </summary>
         /// <returns>the serialized value.</returns>
-        /// <remarks>http://redis.io/commands/dump</remarks>
+        /// <remarks>https://redis.io/commands/dump</remarks>
         Task<byte[]> KeyDumpAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns if key exists.
         /// </summary>
         /// <returns>1 if the key exists. 0 if the key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/exists</remarks>
+        /// <remarks>https://redis.io/commands/exists</remarks>
         Task<bool> KeyExistsAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -294,9 +294,9 @@ namespace StackExchange.Redis
         /// <remarks>If key is updated before the timeout has expired, then the timeout is removed as if the PERSIST command was invoked on key.
         /// For Redis versions &lt; 2.1.3, existing timeouts cannot be overwritten. So, if key already has an associated timeout, it will do nothing and return 0. Since Redis 2.1.3, you can update the timeout of a key. It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.</remarks>
         /// <returns>1 if the timeout was set. 0 if key does not exist or the timeout could not be set.</returns>
-        /// <remarks>http://redis.io/commands/expire</remarks>
-        /// <remarks>http://redis.io/commands/pexpire</remarks>
-        /// <remarks>http://redis.io/commands/persist</remarks>
+        /// <remarks>https://redis.io/commands/expire</remarks>
+        /// <remarks>https://redis.io/commands/pexpire</remarks>
+        /// <remarks>https://redis.io/commands/persist</remarks>
         Task<bool> KeyExpireAsync(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -305,70 +305,70 @@ namespace StackExchange.Redis
         /// <remarks>If key is updated before the timeout has expired, then the timeout is removed as if the PERSIST command was invoked on key.
         /// For Redis versions &lt; 2.1.3, existing timeouts cannot be overwritten. So, if key already has an associated timeout, it will do nothing and return 0. Since Redis 2.1.3, you can update the timeout of a key. It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.</remarks>
         /// <returns>1 if the timeout was set. 0 if key does not exist or the timeout could not be set.</returns>
-        /// <remarks>http://redis.io/commands/expireat</remarks>
-        /// <remarks>http://redis.io/commands/pexpireat</remarks>
-        /// <remarks>http://redis.io/commands/persist</remarks>
+        /// <remarks>https://redis.io/commands/expireat</remarks>
+        /// <remarks>https://redis.io/commands/pexpireat</remarks>
+        /// <remarks>https://redis.io/commands/persist</remarks>
         Task<bool> KeyExpireAsync(RedisKey key, DateTime? expiry, CommandFlags flags = CommandFlags.None);
 
 
         /// <summary>
         /// Atomically transfer a key from a source Redis instance to a destination Redis instance. On success the key is deleted from the original instance by default, and is guaranteed to exist in the target instance.
         /// </summary>
-        /// <remarks>http://redis.io/commands/MIGRATE</remarks>
+        /// <remarks>https://redis.io/commands/MIGRATE</remarks>
         Task KeyMigrateAsync(RedisKey key, EndPoint toServer, int toDatabase = 0, int timeoutMilliseconds = 0, MigrateOptions migrateOptions = MigrateOptions.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Move key from the currently selected database (see SELECT) to the specified destination database. When key already exists in the destination database, or it does not exist in the source database, it does nothing. It is possible to use MOVE as a locking primitive because of this.
         /// </summary>
         /// <returns>1 if key was moved; 0 if key was not moved.</returns>
-        /// <remarks>http://redis.io/commands/move</remarks>
+        /// <remarks>https://redis.io/commands/move</remarks>
         Task<bool> KeyMoveAsync(RedisKey key, int database, CommandFlags flags = CommandFlags.None);
 
         /// <summary>Remove the existing timeout on key, turning the key from volatile (a key with an expire set) to persistent (a key that will never expire as no timeout is associated).</summary>
         /// <returns>1 if the timeout was removed. 0 if key does not exist or does not have an associated timeout.</returns>
-        /// <remarks>http://redis.io/commands/persist</remarks>
+        /// <remarks>https://redis.io/commands/persist</remarks>
         Task<bool> KeyPersistAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return a random key from the currently selected database.
         /// </summary>
         /// <returns>the random key, or nil when the database is empty.</returns>
-        /// <remarks>http://redis.io/commands/randomkey</remarks>
+        /// <remarks>https://redis.io/commands/randomkey</remarks>
         Task<RedisKey> KeyRandomAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Renames key to newkey. It returns an error when the source and destination names are the same, or when key does not exist. 
         /// </summary>
-        /// <returns>http://redis.io/commands/rename</returns>
-        /// <remarks>http://redis.io/commands/renamenx</remarks>
+        /// <returns>https://redis.io/commands/rename</returns>
+        /// <remarks>https://redis.io/commands/renamenx</remarks>
         Task<bool> KeyRenameAsync(RedisKey key, RedisKey newKey, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Create a key associated with a value that is obtained by deserializing the provided serialized value (obtained via DUMP).
         /// If ttl is 0 the key is created without any expire, otherwise the specified expire time(in milliseconds) is set.
         /// </summary>
-        /// <remarks>http://redis.io/commands/restore</remarks>
+        /// <remarks>https://redis.io/commands/restore</remarks>
         Task KeyRestoreAsync(RedisKey key, byte[] value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the remaining time to live of a key that has a timeout.  This introspection capability allows a Redis client to check how many seconds a given key will continue to be part of the dataset.
         /// </summary>
         /// <returns>TTL, or nil when key does not exist or does not have a timeout.</returns>
-        /// <remarks>http://redis.io/commands/ttl</remarks>
+        /// <remarks>https://redis.io/commands/ttl</remarks>
         Task<TimeSpan?> KeyTimeToLiveAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the string representation of the type of the value stored at key. The different types that can be returned are: string, list, set, zset and hash.
         /// </summary>
         /// <returns>type of key, or none when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/type</remarks>
+        /// <remarks>https://redis.io/commands/type</remarks>
         Task<RedisType> KeyTypeAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the element at index index in the list stored at key. The index is zero-based, so 0 means the first element, 1 the second element and so on. Negative indices can be used to designate elements starting at the tail of the list. Here, -1 means the last element, -2 means the penultimate and so forth.
         /// </summary>
         /// <returns>the requested element, or nil when index is out of range.</returns>
-        /// <remarks>http://redis.io/commands/lindex</remarks>
+        /// <remarks>https://redis.io/commands/lindex</remarks>
         Task<RedisValue> ListGetByIndexAsync(RedisKey key, long index, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -376,7 +376,7 @@ namespace StackExchange.Redis
         /// When key does not exist, it is considered an empty list and no operation is performed.
         /// </summary>
         /// <returns>the length of the list after the insert operation, or -1 when the value pivot was not found.</returns>
-        /// <remarks>http://redis.io/commands/linsert</remarks>
+        /// <remarks>https://redis.io/commands/linsert</remarks>
         Task<long> ListInsertAfterAsync(RedisKey key, RedisValue pivot, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -384,22 +384,22 @@ namespace StackExchange.Redis
         /// When key does not exist, it is considered an empty list and no operation is performed.
         /// </summary>
         /// <returns>the length of the list after the insert operation, or -1 when the value pivot was not found.</returns>
-        /// <remarks>http://redis.io/commands/linsert</remarks>
+        /// <remarks>https://redis.io/commands/linsert</remarks>
         Task<long> ListInsertBeforeAsync(RedisKey key, RedisValue pivot, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes and returns the first element of the list stored at key.
         /// </summary>
         /// <returns>the value of the first element, or nil when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/lpop</remarks>
+        /// <remarks>https://redis.io/commands/lpop</remarks>
         Task<RedisValue> ListLeftPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Insert the specified value at the head of the list stored at key. If key does not exist, it is created as empty list before performing the push operations.
         /// </summary>
         /// <returns>the length of the list after the push operations.</returns>
-        /// <remarks>http://redis.io/commands/lpush</remarks>
-        /// <remarks>http://redis.io/commands/lpushx</remarks>
+        /// <remarks>https://redis.io/commands/lpush</remarks>
+        /// <remarks>https://redis.io/commands/lpushx</remarks>
         Task<long> ListLeftPushAsync(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -407,14 +407,14 @@ namespace StackExchange.Redis
         /// Elements are inserted one after the other to the head of the list, from the leftmost element to the rightmost element. So for instance the command LPUSH mylist a b c will result into a list containing c as first element, b as second element and a as third element.
         /// </summary>
         /// <returns>the length of the list after the push operations.</returns>
-        /// <remarks>http://redis.io/commands/lpush</remarks>
+        /// <remarks>https://redis.io/commands/lpush</remarks>
         Task<long> ListLeftPushAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the length of the list stored at key. If key does not exist, it is interpreted as an empty list and 0 is returned. 
         /// </summary>
         /// <returns>the length of the list at key.</returns>
-        /// <remarks>http://redis.io/commands/llen</remarks>
+        /// <remarks>https://redis.io/commands/llen</remarks>
         Task<long> ListLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -423,7 +423,7 @@ namespace StackExchange.Redis
         /// Note that if you have a list of numbers from 0 to 100, LRANGE list 0 10 will return 11 elements, that is, the rightmost item is included. 
         /// </summary>
         /// <returns>list of elements in the specified range.</returns>
-        /// <remarks>http://redis.io/commands/lrange</remarks>
+        /// <remarks>https://redis.io/commands/lrange</remarks>
         Task<RedisValue[]> ListRangeAsync(RedisKey key, long start = 0, long stop = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -433,28 +433,28 @@ namespace StackExchange.Redis
         /// count = 0: Remove all elements equal to value.
         /// </summary>
         /// <returns>the number of removed elements.</returns>
-        /// <remarks>http://redis.io/commands/lrem</remarks>
+        /// <remarks>https://redis.io/commands/lrem</remarks>
         Task<long> ListRemoveAsync(RedisKey key, RedisValue value, long count = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes and returns the last element of the list stored at key.
         /// </summary>
-        /// <remarks>http://redis.io/commands/rpop</remarks>
+        /// <remarks>https://redis.io/commands/rpop</remarks>
         Task<RedisValue> ListRightPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Atomically returns and removes the last element (tail) of the list stored at source, and pushes the element at the first element (head) of the list stored at destination.
         /// </summary>
         /// <returns>the element being popped and pushed.</returns>
-        /// <remarks>http://redis.io/commands/rpoplpush</remarks>
+        /// <remarks>https://redis.io/commands/rpoplpush</remarks>
         Task<RedisValue> ListRightPopLeftPushAsync(RedisKey source, RedisKey destination, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Insert the specified value at the tail of the list stored at key. If key does not exist, it is created as empty list before performing the push operation.
         /// </summary>
         /// <returns>the length of the list after the push operation.</returns>
-        /// <remarks>http://redis.io/commands/rpush</remarks>
-        /// <remarks>http://redis.io/commands/rpushx</remarks>
+        /// <remarks>https://redis.io/commands/rpush</remarks>
+        /// <remarks>https://redis.io/commands/rpushx</remarks>
         Task<long> ListRightPushAsync(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -462,13 +462,13 @@ namespace StackExchange.Redis
         /// Elements are inserted one after the other to the tail of the list, from the leftmost element to the rightmost element. So for instance the command RPUSH mylist a b c will result into a list containing a as first element, b as second element and c as third element.
         /// </summary>
         /// <returns>the length of the list after the push operation.</returns>
-        /// <remarks>http://redis.io/commands/rpush</remarks>
+        /// <remarks>https://redis.io/commands/rpush</remarks>
         Task<long> ListRightPushAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Sets the list element at index to value. For more information on the index argument, see ListGetByIndex. An error is returned for out of range indexes.
         /// </summary>
-        /// <remarks>http://redis.io/commands/lset</remarks>
+        /// <remarks>https://redis.io/commands/lset</remarks>
         Task ListSetByIndexAsync(RedisKey key, long index, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -476,7 +476,7 @@ namespace StackExchange.Redis
         /// For example: LTRIM foobar 0 2 will modify the list stored at foobar so that only the first three elements of the list will remain.
         /// start and end can also be negative numbers indicating offsets from the end of the list, where -1 is the last element of the list, -2 the penultimate element and so on.
         /// </summary>
-        /// <remarks>http://redis.io/commands/ltrim</remarks>
+        /// <remarks>https://redis.io/commands/ltrim</remarks>
         Task ListTrimAsync(RedisKey key, long start, long stop, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -503,13 +503,13 @@ namespace StackExchange.Redis
         /// Posts a message to the given channel.
         /// </summary>
         /// <returns>the number of clients that received the message.</returns>
-        /// <remarks>http://redis.io/commands/publish</remarks>
+        /// <remarks>https://redis.io/commands/publish</remarks>
         Task<long> PublishAsync(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Execute a Lua script against the server
         /// </summary>
-        /// <remarks>http://redis.io/commands/eval, http://redis.io/commands/evalsha</remarks>
+        /// <remarks>https://redis.io/commands/eval, https://redis.io/commands/evalsha</remarks>
         /// <returns>A dynamic representation of the script's result</returns>
         Task<RedisResult> ScriptEvaluateAsync(string script, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None);
 
@@ -533,7 +533,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Execute a Lua script against the server using just the SHA1 hash
         /// </summary>
-        /// <remarks>http://redis.io/commands/evalsha</remarks>
+        /// <remarks>https://redis.io/commands/evalsha</remarks>
         /// <returns>A dynamic representation of the script's result</returns>
         Task<RedisResult> ScriptEvaluateAsync(byte[] hash, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None);
 
@@ -554,71 +554,71 @@ namespace StackExchange.Redis
         /// Add the specified member to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <returns>True if the specified member was not already present in the set, else False</returns>
-        /// <remarks>http://redis.io/commands/sadd</remarks>
+        /// <remarks>https://redis.io/commands/sadd</remarks>
         Task<bool> SetAddAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Add the specified members to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <returns>the number of elements that were added to the set, not including all the elements already present into the set.</returns>
-        /// <remarks>http://redis.io/commands/sadd</remarks>
+        /// <remarks>https://redis.io/commands/sadd</remarks>
         Task<long> SetAddAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// This command is equal to SetCombine, but instead of returning the resulting set, it is stored in destination. If destination already exists, it is overwritten.
         /// </summary>
         /// <returns>the number of elements in the resulting set.</returns>
-        /// <remarks>http://redis.io/commands/sunionstore</remarks>
-        /// <remarks>http://redis.io/commands/sinterstore</remarks>
-        /// <remarks>http://redis.io/commands/sdiffstore</remarks>
+        /// <remarks>https://redis.io/commands/sunionstore</remarks>
+        /// <remarks>https://redis.io/commands/sinterstore</remarks>
+        /// <remarks>https://redis.io/commands/sdiffstore</remarks>
         Task<long> SetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// This command is equal to SetCombine, but instead of returning the resulting set, it is stored in destination. If destination already exists, it is overwritten.
         /// </summary>
         /// <returns>the number of elements in the resulting set.</returns>
-        /// <remarks>http://redis.io/commands/sunionstore</remarks>
-        /// <remarks>http://redis.io/commands/sinterstore</remarks>
-        /// <remarks>http://redis.io/commands/sdiffstore</remarks>
+        /// <remarks>https://redis.io/commands/sunionstore</remarks>
+        /// <remarks>https://redis.io/commands/sinterstore</remarks>
+        /// <remarks>https://redis.io/commands/sdiffstore</remarks>
         Task<long> SetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the members of the set resulting from the specified operation against the given sets.
         /// </summary>
         /// <returns>list with members of the resulting set.</returns>
-        /// <remarks>http://redis.io/commands/sunion</remarks>
-        /// <remarks>http://redis.io/commands/sinter</remarks>
-        /// <remarks>http://redis.io/commands/sdiff</remarks>
+        /// <remarks>https://redis.io/commands/sunion</remarks>
+        /// <remarks>https://redis.io/commands/sinter</remarks>
+        /// <remarks>https://redis.io/commands/sdiff</remarks>
         Task<RedisValue[]> SetCombineAsync(SetOperation operation, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the members of the set resulting from the specified operation against the given sets.
         /// </summary>
         /// <returns>list with members of the resulting set.</returns>
-        /// <remarks>http://redis.io/commands/sunion</remarks>
-        /// <remarks>http://redis.io/commands/sinter</remarks>
-        /// <remarks>http://redis.io/commands/sdiff</remarks>
+        /// <remarks>https://redis.io/commands/sunion</remarks>
+        /// <remarks>https://redis.io/commands/sinter</remarks>
+        /// <remarks>https://redis.io/commands/sdiff</remarks>
         Task<RedisValue[]> SetCombineAsync(SetOperation operation, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns if member is a member of the set stored at key.
         /// </summary>
         /// <returns>1 if the element is a member of the set. 0 if the element is not a member of the set, or if key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/sismember</remarks>
+        /// <remarks>https://redis.io/commands/sismember</remarks>
         Task<bool> SetContainsAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the set cardinality (number of elements) of the set stored at key.
         /// </summary>
         /// <returns>the cardinality (number of elements) of the set, or 0 if key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/scard</remarks>
+        /// <remarks>https://redis.io/commands/scard</remarks>
         Task<long> SetLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns all the members of the set value stored at key.
         /// </summary>
         /// <returns>all elements of the set.</returns>
-        /// <remarks>http://redis.io/commands/smembers</remarks>
+        /// <remarks>https://redis.io/commands/smembers</remarks>
         Task<RedisValue[]> SetMembersAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -626,21 +626,21 @@ namespace StackExchange.Redis
         /// When the specified element already exists in the destination set, it is only removed from the source set.
         /// </summary>
         /// <returns>1 if the element is moved. 0 if the element is not a member of source and no operation was performed.</returns>
-        /// <remarks>http://redis.io/commands/smove</remarks>
+        /// <remarks>https://redis.io/commands/smove</remarks>
         Task<bool> SetMoveAsync(RedisKey source, RedisKey destination, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes and returns a random element from the set value stored at key.
         /// </summary>
         /// <returns>the removed element, or nil when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/spop</remarks>
+        /// <remarks>https://redis.io/commands/spop</remarks>
         Task<RedisValue> SetPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return a random element from the set value stored at key.
         /// </summary>
         /// <returns>the randomly selected element, or nil when key does not exist</returns>
-        /// <remarks>http://redis.io/commands/srandmember</remarks>
+        /// <remarks>https://redis.io/commands/srandmember</remarks>
         Task<RedisValue> SetRandomMemberAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -648,31 +648,31 @@ namespace StackExchange.Redis
         /// In this case the numer of returned elements is the absolute value of the specified count.
         /// </summary>
         /// <returns>an array of elements, or an empty array when key does not exist</returns>
-        /// <remarks>http://redis.io/commands/srandmember</remarks>
+        /// <remarks>https://redis.io/commands/srandmember</remarks>
         Task<RedisValue[]> SetRandomMembersAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Remove the specified member from the set stored at key.  Specified members that are not a member of this set are ignored.
         /// </summary>
         /// <returns>True if the specified member was already present in the set, else False</returns>
-        /// <remarks>http://redis.io/commands/srem</remarks>
+        /// <remarks>https://redis.io/commands/srem</remarks>
         Task<bool> SetRemoveAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Remove the specified members from the set stored at key. Specified members that are not a member of this set are ignored.
         /// </summary>
         /// <returns>the number of members that were removed from the set, not including non existing members.</returns>
-        /// <remarks>http://redis.io/commands/srem</remarks>
+        /// <remarks>https://redis.io/commands/srem</remarks>
         Task<long> SetRemoveAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Sorts a list, set or sorted set (numerically or alphabetically, ascending by default); By default, the elements themselves are compared, but the values can also be
         /// used to perform external key-lookups using the <c>by</c> parameter. By default, the elements themselves are returned, but external key-lookups (one or many) can
         /// be performed instead by specifying the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
-        /// Referring to the <a href="http://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended. When used in hashes, <c>by</c> and <c>get</c>
+        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended. When used in hashes, <c>by</c> and <c>get</c>
         /// can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
         /// </summary>
-        /// <remarks>http://redis.io/commands/sort</remarks>
+        /// <remarks>https://redis.io/commands/sort</remarks>
         /// <returns>Returns the number of elements stored in the new list</returns>
         [IgnoreNamePrefix]
         Task<long> SortAndStoreAsync(RedisKey destination, RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default(RedisValue), RedisValue[] get = null, CommandFlags flags = CommandFlags.None);
@@ -681,10 +681,10 @@ namespace StackExchange.Redis
         /// Sorts a list, set or sorted set (numerically or alphabetically, ascending by default); By default, the elements themselves are compared, but the values can also be
         /// used to perform external key-lookups using the <c>by</c> parameter. By default, the elements themselves are returned, but external key-lookups (one or many) can
         /// be performed instead by specifying the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
-        /// Referring to the <a href="http://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended. When used in hashes, <c>by</c> and <c>get</c>
+        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended. When used in hashes, <c>by</c> and <c>get</c>
         /// can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
         /// </summary>
-        /// <remarks>http://redis.io/commands/sort</remarks>
+        /// <remarks>https://redis.io/commands/sort</remarks>
         /// <returns>Returns the sorted elements, or the external values if <c>get</c> is specified</returns>
         [IgnoreNamePrefix]
         Task<RedisValue[]> SortAsync(RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default(RedisValue), RedisValue[] get = null, CommandFlags flags = CommandFlags.None);
@@ -693,36 +693,36 @@ namespace StackExchange.Redis
         /// Adds the specified member with the specified score to the sorted set stored at key. If the specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <returns>True if the value was added, False if it already existed (the score is still updated)</returns>
-        /// <remarks>http://redis.io/commands/zadd</remarks>
+        /// <remarks>https://redis.io/commands/zadd</remarks>
         Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, CommandFlags flags);
 
         /// <summary>
         /// Adds the specified member with the specified score to the sorted set stored at key. If the specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <returns>True if the value was added, False if it already existed (the score is still updated)</returns>
-        /// <remarks>http://redis.io/commands/zadd</remarks>
+        /// <remarks>https://redis.io/commands/zadd</remarks>
         Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Adds all the specified members with the specified scores to the sorted set stored at key. If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <returns>The number of elements added to the sorted sets, not including elements already existing for which the score was updated.</returns>
-        /// <remarks>http://redis.io/commands/zadd</remarks>
+        /// <remarks>https://redis.io/commands/zadd</remarks>
         Task<long> SortedSetAddAsync(RedisKey key, SortedSetEntry[] values, CommandFlags flags);
 
         /// <summary>
         /// Adds all the specified members with the specified scores to the sorted set stored at key. If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <returns>The number of elements added to the sorted sets, not including elements already existing for which the score was updated.</returns>
-        /// <remarks>http://redis.io/commands/zadd</remarks>
+        /// <remarks>https://redis.io/commands/zadd</remarks>
         Task<long> SortedSetAddAsync(RedisKey key, SortedSetEntry[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Computes a set operation over two sorted sets, and stores the result in destination, optionally performing 
         /// a specific aggregation (defaults to sum)
         /// </summary>
-        /// <remarks>http://redis.io/commands/zunionstore</remarks>
-        /// <remarks>http://redis.io/commands/zinterstore</remarks>
+        /// <remarks>https://redis.io/commands/zunionstore</remarks>
+        /// <remarks>https://redis.io/commands/zinterstore</remarks>
         /// <returns>the number of elements in the resulting sorted set at destination</returns>
         Task<long> SortedSetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
@@ -730,8 +730,8 @@ namespace StackExchange.Redis
         /// Computes a set operation over multiple sorted sets (optionally using per-set weights), and stores the result in destination, optionally performing 
         /// a specific aggregation (defaults to sum)
         /// </summary>
-        /// <remarks>http://redis.io/commands/zunionstore</remarks>
-        /// <remarks>http://redis.io/commands/zinterstore</remarks>
+        /// <remarks>https://redis.io/commands/zunionstore</remarks>
+        /// <remarks>https://redis.io/commands/zinterstore</remarks>
         /// <returns>the number of elements in the resulting sorted set at destination</returns>
         Task<long> SortedSetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey[] keys, double[] weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
@@ -739,21 +739,21 @@ namespace StackExchange.Redis
         /// Decrements the score of member in the sorted set stored at key by decrement. If member does not exist in the sorted set, it is added with -decrement as its score (as if its previous score was 0.0).
         /// </summary>
         /// <returns>the new score of member</returns>
-        /// <remarks>http://redis.io/commands/zincrby</remarks>
+        /// <remarks>https://redis.io/commands/zincrby</remarks>
         Task<double> SortedSetDecrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Increments the score of member in the sorted set stored at key by increment. If member does not exist in the sorted set, it is added with increment as its score (as if its previous score was 0.0).
         /// </summary>
         /// <returns>the new score of member</returns>
-        /// <remarks>http://redis.io/commands/zincrby</remarks>
+        /// <remarks>https://redis.io/commands/zincrby</remarks>
         Task<double> SortedSetIncrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the sorted set cardinality (number of elements) of the sorted set stored at key.
         /// </summary>
         /// <returns>the cardinality (number of elements) of the sorted set, or 0 if key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/zcard</remarks>
+        /// <remarks>https://redis.io/commands/zcard</remarks>
         Task<long> SortedSetLengthAsync(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -768,8 +768,8 @@ namespace StackExchange.Redis
         /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on. They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
         /// </summary>
         /// <returns>list of elements in the specified range</returns>
-        /// <remarks>http://redis.io/commands/zrange</remarks>
-        /// <remarks>http://redis.io/commands/zrevrange</remarks>
+        /// <remarks>https://redis.io/commands/zrange</remarks>
+        /// <remarks>https://redis.io/commands/zrevrange</remarks>
         Task<RedisValue[]> SortedSetRangeByRankAsync(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -777,8 +777,8 @@ namespace StackExchange.Redis
         /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on. They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
         /// </summary>
         /// <returns>list of elements in the specified range</returns>
-        /// <remarks>http://redis.io/commands/zrange</remarks>
-        /// <remarks>http://redis.io/commands/zrevrange</remarks>
+        /// <remarks>https://redis.io/commands/zrange</remarks>
+        /// <remarks>https://redis.io/commands/zrevrange</remarks>
         Task<SortedSetEntry[]> SortedSetRangeByRankWithScoresAsync(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -786,8 +786,8 @@ namespace StackExchange.Redis
         /// Start and stop are used to specify the min and max range for score values. Similar to other range methods the values are inclusive.
         /// </summary>
         /// <returns>list of elements in the specified score range</returns>
-        /// <remarks>http://redis.io/commands/zrangebyscore</remarks>
-        /// <remarks>http://redis.io/commands/zrevrangebyscore</remarks>
+        /// <remarks>https://redis.io/commands/zrangebyscore</remarks>
+        /// <remarks>https://redis.io/commands/zrevrangebyscore</remarks>
         Task<RedisValue[]> SortedSetRangeByScoreAsync(RedisKey key,
             double start = double.NegativeInfinity, double stop = double.PositiveInfinity,
             Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1,
@@ -798,8 +798,8 @@ namespace StackExchange.Redis
         /// Start and stop are used to specify the min and max range for score values. Similar to other range methods the values are inclusive.
         /// </summary>
         /// <returns>list of elements in the specified score range</returns>
-        /// <remarks>http://redis.io/commands/zrangebyscore</remarks>
-        /// <remarks>http://redis.io/commands/zrevrangebyscore</remarks>
+        /// <remarks>https://redis.io/commands/zrangebyscore</remarks>
+        /// <remarks>https://redis.io/commands/zrevrangebyscore</remarks>
         Task<SortedSetEntry[]> SortedSetRangeByScoreWithScoresAsync(RedisKey key,
             double start = double.NegativeInfinity, double stop = double.PositiveInfinity,
             Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1,
@@ -808,7 +808,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command returns all the elements in the sorted set at key with a value between min and max.
         /// </summary>
-        /// <remarks>http://redis.io/commands/zrangebylex</remarks>
+        /// <remarks>https://redis.io/commands/zrangebylex</remarks>
         /// <returns>list of elements in the specified score range.</returns>
         Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue),
             Exclude exclude = Exclude.None, long skip = 0, long take = -1,
@@ -818,49 +818,49 @@ namespace StackExchange.Redis
         /// Returns the rank of member in the sorted set stored at key, by default with the scores ordered from low to high. The rank (or index) is 0-based, which means that the member with the lowest score has rank 0.
         /// </summary>
         /// <returns>If member exists in the sorted set, the rank of member; If member does not exist in the sorted set or key does not exist, null</returns>
-        /// <remarks>http://redis.io/commands/zrank</remarks>
-        /// <remarks>http://redis.io/commands/zrevrank</remarks>
+        /// <remarks>https://redis.io/commands/zrank</remarks>
+        /// <remarks>https://redis.io/commands/zrevrank</remarks>
         Task<long?> SortedSetRankAsync(RedisKey key, RedisValue member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes the specified member from the sorted set stored at key. Non existing members are ignored.
         /// </summary>
         /// <returns>True if the member existed in the sorted set and was removed; False otherwise.</returns>
-        /// <remarks>http://redis.io/commands/zrem</remarks>
+        /// <remarks>https://redis.io/commands/zrem</remarks>
         Task<bool> SortedSetRemoveAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes the specified members from the sorted set stored at key. Non existing members are ignored.
         /// </summary>
         /// <returns>The number of members removed from the sorted set, not including non existing members.</returns>
-        /// <remarks>http://redis.io/commands/zrem</remarks>
+        /// <remarks>https://redis.io/commands/zrem</remarks>
         Task<long> SortedSetRemoveAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes all elements in the sorted set stored at key with rank between start and stop. Both start and stop are 0 -based indexes with 0 being the element with the lowest score. These indexes can be negative numbers, where they indicate offsets starting at the element with the highest score. For example: -1 is the element with the highest score, -2 the element with the second highest score and so forth.
         /// </summary>
         /// <returns> the number of elements removed.</returns>
-        /// <remarks>http://redis.io/commands/zremrangebyrank</remarks>
+        /// <remarks>https://redis.io/commands/zremrangebyrank</remarks>
         Task<long> SortedSetRemoveRangeByRankAsync(RedisKey key, long start, long stop, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes all elements in the sorted set stored at key with a score between min and max (inclusive by default).
         /// </summary>
         /// <returns> the number of elements removed.</returns>
-        /// <remarks>http://redis.io/commands/zremrangebyscore</remarks>
+        /// <remarks>https://redis.io/commands/zremrangebyscore</remarks>
         Task<long> SortedSetRemoveRangeByScoreAsync(RedisKey key, double start, double stop, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command removes all elements in the sorted set stored at key between the lexicographical range specified by min and max.
         /// </summary>
-        /// <remarks>http://redis.io/commands/zremrangebylex</remarks>
+        /// <remarks>https://redis.io/commands/zremrangebylex</remarks>
         /// <returns>the number of elements removed.</returns>
         Task<long> SortedSetRemoveRangeByValueAsync(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// Returns the score of member in the sorted set at key; If member does not exist in the sorted set, or key does not exist, nil is returned.
         /// </summary>
         /// <returns>the score of member</returns>
-        /// <remarks>http://redis.io/commands/zscore</remarks>
+        /// <remarks>https://redis.io/commands/zscore</remarks>
         Task<double?> SortedSetScoreAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
 
@@ -869,7 +869,7 @@ namespace StackExchange.Redis
         /// so APPEND will be similar to SET in this special case.
         /// </summary>
         /// <returns>the length of the string after the append operation.</returns>
-        /// <remarks>http://redis.io/commands/append</remarks>
+        /// <remarks>https://redis.io/commands/append</remarks>
         Task<long> StringAppendAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -878,7 +878,7 @@ namespace StackExchange.Redis
         /// Like for the GETRANGE command start and end can contain negative values in order to index bytes starting from the end of the string, where -1 is the last byte, -2 is the penultimate, and so forth.
         /// </summary>
         /// <returns>The number of bits set to 1</returns>
-        /// <remarks>http://redis.io/commands/bitcount</remarks>
+        /// <remarks>https://redis.io/commands/bitcount</remarks>
         Task<long> StringBitCountAsync(RedisKey key, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -888,7 +888,7 @@ namespace StackExchange.Redis
         /// The result of the operation is always stored at destkey.
         /// </summary>
         /// <returns>The size of the string stored in the destination key, that is equal to the size of the longest input string.</returns>
-        /// <remarks>http://redis.io/commands/bitop</remarks>
+        /// <remarks>https://redis.io/commands/bitop</remarks>
         Task<long> StringBitOperationAsync(Bitwise operation, RedisKey destination, RedisKey first, RedisKey second = default(RedisKey), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -897,7 +897,7 @@ namespace StackExchange.Redis
         /// The result of the operation is always stored at destkey.
         /// </summary>
         /// <returns>The size of the string stored in the destination key, that is equal to the size of the longest input string.</returns>
-        /// <remarks>http://redis.io/commands/bitop</remarks>
+        /// <remarks>https://redis.io/commands/bitop</remarks>
         Task<long> StringBitOperationAsync(Bitwise operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -907,34 +907,34 @@ namespace StackExchange.Redis
         /// </summary>
         /// <returns>The command returns the position of the first bit set to 1 or 0 according to the request.
         /// If we look for set bits(the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.</returns>
-        /// <remarks>http://redis.io/commands/bitpos</remarks>
+        /// <remarks>https://redis.io/commands/bitpos</remarks>
         Task<long> StringBitPositionAsync(RedisKey key, bool bit, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Decrements the number stored at key by decrement. If the key does not exist, it is set to 0 before performing the operation. An error is returned if the key contains a value of the wrong type or contains a string that is not representable as integer. This operation is limited to 64 bit signed integers.
         /// </summary>
         /// <returns> the value of key after the increment</returns>
-        /// <remarks>http://redis.io/commands/decrby</remarks>
-        /// <remarks>http://redis.io/commands/decr</remarks>
+        /// <remarks>https://redis.io/commands/decrby</remarks>
+        /// <remarks>https://redis.io/commands/decr</remarks>
         Task<long> StringDecrementAsync(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Decrements the string representing a floating point number stored at key by the specified increment. If the key does not exist, it is set to 0 before performing the operation. The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.
         /// </summary>
         /// <returns>the value of key after the increment</returns>
-        /// <remarks>http://redis.io/commands/incrbyfloat</remarks>
+        /// <remarks>https://redis.io/commands/incrbyfloat</remarks>
         Task<double> StringDecrementAsync(RedisKey key, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <returns>the value of key, or nil when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/get</remarks>
+        /// <remarks>https://redis.io/commands/get</remarks>
         Task<RedisValue> StringGetAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// Returns the values of all specified keys. For every key that does not hold a string value or does not exist, the special value nil is returned.
         /// </summary>
-        /// <remarks>http://redis.io/commands/mget</remarks>
+        /// <remarks>https://redis.io/commands/mget</remarks>
         Task<RedisValue[]> StringGetAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -942,20 +942,20 @@ namespace StackExchange.Redis
         /// When offset is beyond the string length, the string is assumed to be a contiguous space with 0 bits.
         /// </summary>
         /// <returns>the bit value stored at offset.</returns>
-        /// <remarks>http://redis.io/commands/getbit</remarks>
+        /// <remarks>https://redis.io/commands/getbit</remarks>
         Task<bool> StringGetBitAsync(RedisKey key, long offset, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the substring of the string value stored at key, determined by the offsets start and end (both are inclusive). Negative offsets can be used in order to provide an offset starting from the end of the string. So -1 means the last character, -2 the penultimate and so forth.
         /// </summary>
         /// <returns>the substring of the string value stored at key</returns>
-        /// <remarks>http://redis.io/commands/getrange</remarks>
+        /// <remarks>https://redis.io/commands/getrange</remarks>
         Task<RedisValue> StringGetRangeAsync(RedisKey key, long start, long end, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Atomically sets key to value and returns the old value stored at key.
         /// </summary>
-        /// <remarks>http://redis.io/commands/getset</remarks>
+        /// <remarks>https://redis.io/commands/getset</remarks>
         /// <returns> the old value stored at key, or nil when key did not exist.</returns>
         Task<RedisValue> StringGetSetAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
@@ -963,41 +963,41 @@ namespace StackExchange.Redis
         /// Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <returns>the value of key, or nil when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/get</remarks>
+        /// <remarks>https://redis.io/commands/get</remarks>
         Task<RedisValueWithExpiry> StringGetWithExpiryAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Increments the number stored at key by increment. If the key does not exist, it is set to 0 before performing the operation. An error is returned if the key contains a value of the wrong type or contains a string that is not representable as integer. This operation is limited to 64 bit signed integers.
         /// </summary>
         /// <returns>the value of key after the increment</returns>
-        /// <remarks>http://redis.io/commands/incrby</remarks>
-        /// <remarks>http://redis.io/commands/incr</remarks>
+        /// <remarks>https://redis.io/commands/incrby</remarks>
+        /// <remarks>https://redis.io/commands/incr</remarks>
         Task<long> StringIncrementAsync(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Increment the string representing a floating point number stored at key by the specified increment. If the key does not exist, it is set to 0 before performing the operation. The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.
         /// </summary>
         /// <returns>the value of key after the increment</returns>
-        /// <remarks>http://redis.io/commands/incrbyfloat</remarks>
+        /// <remarks>https://redis.io/commands/incrbyfloat</remarks>
         Task<double> StringIncrementAsync(RedisKey key, double value, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// Returns the length of the string value stored at key.
         /// </summary>
         /// <returns>the length of the string at key, or 0 when key does not exist.</returns>
-        /// <remarks>http://redis.io/commands/strlen</remarks>
+        /// <remarks>https://redis.io/commands/strlen</remarks>
         Task<long> StringLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Set key to hold the string value. If key already holds a value, it is overwritten, regardless of its type.
         /// </summary>
-        /// <remarks>http://redis.io/commands/set</remarks>
+        /// <remarks>https://redis.io/commands/set</remarks>
         Task<bool> StringSetAsync(RedisKey key, RedisValue value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// Sets the given keys to their respective values. If "not exists" is specified, this will not perform any operation at all even if just a single key already exists.
         /// </summary>
         /// <returns>True if the keys were set, else False</returns>
-        /// <remarks>http://redis.io/commands/mset</remarks>
-        /// <remarks>http://redis.io/commands/msetnx</remarks>
+        /// <remarks>https://redis.io/commands/mset</remarks>
+        /// <remarks>https://redis.io/commands/msetnx</remarks>
         Task<bool> StringSetAsync(KeyValuePair<RedisKey, RedisValue>[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1005,13 +1005,13 @@ namespace StackExchange.Redis
         /// The bit is either set or cleared depending on value, which can be either 0 or 1. When key does not exist, a new string value is created.The string is grown to make sure it can hold a bit at offset.
         /// </summary>
         /// <returns>the original bit value stored at offset.</returns>
-        /// <remarks>http://redis.io/commands/setbit</remarks>
+        /// <remarks>https://redis.io/commands/setbit</remarks>
         Task<bool> StringSetBitAsync(RedisKey key, long offset, bool bit, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// Overwrites part of the string stored at key, starting at the specified offset, for the entire length of value. If the offset is larger than the current length of the string at key, the string is padded with zero-bytes to make offset fit. Non-existing keys are considered as empty strings, so this command will make sure it holds a string large enough to be able to set value at offset.
         /// </summary>
         /// <returns>the length of the string after it was modified by the command.</returns>
-        /// <remarks>http://redis.io/commands/setrange</remarks>
+        /// <remarks>https://redis.io/commands/setrange</remarks>
         Task<RedisValue> StringSetRangeAsync(RedisKey key, long offset, RedisValue value, CommandFlags flags = CommandFlags.None);
     }
 

--- a/StackExchange.Redis/StackExchange/Redis/IRedis.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IRedis.cs
@@ -12,7 +12,7 @@ namespace StackExchange.Redis
         /// This command is often used to test if a connection is still alive, or to measure latency.
         /// </summary>
         /// <returns>The observed latency.</returns>
-        /// <remarks>http://redis.io/commands/ping</remarks>
+        /// <remarks>https://redis.io/commands/ping</remarks>
         TimeSpan Ping(CommandFlags flags = CommandFlags.None);
     }
 

--- a/StackExchange.Redis/StackExchange/Redis/IRedisAsync.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IRedisAsync.cs
@@ -17,7 +17,7 @@ namespace StackExchange.Redis
         /// This command is often used to test if a connection is still alive, or to measure latency.
         /// </summary>
         /// <returns>The observed latency.</returns>
-        /// <remarks>http://redis.io/commands/ping</remarks>
+        /// <remarks>https://redis.io/commands/ping</remarks>
         Task<TimeSpan> PingAsync(CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// Wait for a given asynchronous operation to complete (or timeout), reporting which

--- a/StackExchange.Redis/StackExchange/Redis/IServer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IServer.cs
@@ -57,7 +57,7 @@ namespace StackExchange.Redis
         /// The ip:port should match a line returned by the CLIENT LIST command.
         /// Due to the single-treaded nature of Redis, it is not possible to kill a client connection while it is executing a command.From the client point of view, the connection can never be closed in the middle of the execution of a command.However, the client will notice the connection has been closed only when the next command is sent (and results in network error).
         /// </summary>
-        /// <remarks>http://redis.io/commands/client-kill</remarks>
+        /// <remarks>https://redis.io/commands/client-kill</remarks>
         void ClientKill(EndPoint endpoint, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -65,32 +65,32 @@ namespace StackExchange.Redis
         /// The ip:port should match a line returned by the CLIENT LIST command.
         /// Due to the single-treaded nature of Redis, it is not possible to kill a client connection while it is executing a command.From the client point of view, the connection can never be closed in the middle of the execution of a command.However, the client will notice the connection has been closed only when the next command is sent (and results in network error).
         /// </summary>
-        /// <remarks>http://redis.io/commands/client-kill</remarks>
+        /// <remarks>https://redis.io/commands/client-kill</remarks>
         Task ClientKillAsync(EndPoint endpoint, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The CLIENT KILL command closes multiple connections that match the specified filters
         /// </summary>
         /// <returns>the number of clients killed.</returns>
-        /// <remarks>http://redis.io/commands/client-kill</remarks>
+        /// <remarks>https://redis.io/commands/client-kill</remarks>
         long ClientKill(long? id = null, ClientType? clientType = null, EndPoint endpoint = null, bool skipMe = true, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// The CLIENT KILL command closes multiple connections that match the specified filters
         /// </summary>
         /// <returns>the number of clients killed.</returns>
-        /// <remarks>http://redis.io/commands/client-kill</remarks>
+        /// <remarks>https://redis.io/commands/client-kill</remarks>
         Task<long> ClientKillAsync(long? id = null, ClientType? clientType = null, EndPoint endpoint = null, bool skipMe = true, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The CLIENT LIST command returns information and statistics about the client connections server in a mostly human readable format.
         /// </summary>
-        /// <remarks>http://redis.io/commands/client-list</remarks>
+        /// <remarks>https://redis.io/commands/client-list</remarks>
         ClientInfo[] ClientList(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The CLIENT LIST command returns information and statistics about the client connections server in a mostly human readable format.
         /// </summary>
-        /// <remarks>http://redis.io/commands/client-list</remarks>
+        /// <remarks>https://redis.io/commands/client-list</remarks>
         Task<ClientInfo[]> ClientListAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -117,98 +117,98 @@ namespace StackExchange.Redis
         /// Get all configuration parameters matching the specified pattern.
         /// </summary>
         /// <returns>All matching configuration parameters.</returns>
-        /// <remarks>http://redis.io/commands/config-get</remarks>
+        /// <remarks>https://redis.io/commands/config-get</remarks>
         KeyValuePair<string, string>[] ConfigGet(RedisValue pattern = default(RedisValue), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Get all configuration parameters matching the specified pattern.
         /// </summary>
         /// <returns>All matching configuration parameters.</returns>
-        /// <remarks>http://redis.io/commands/config-get</remarks>
+        /// <remarks>https://redis.io/commands/config-get</remarks>
         Task<KeyValuePair<string, string>[]> ConfigGetAsync(RedisValue pattern = default(RedisValue), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Resets the statistics reported by Redis using the INFO command.
         /// </summary>
-        /// <remarks>http://redis.io/commands/config-resetstat</remarks>
+        /// <remarks>https://redis.io/commands/config-resetstat</remarks>
         void ConfigResetStatistics(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Resets the statistics reported by Redis using the INFO command.
         /// </summary>
-        /// <remarks>http://redis.io/commands/config-resetstat</remarks>
+        /// <remarks>https://redis.io/commands/config-resetstat</remarks>
         Task ConfigResetStatisticsAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The CONFIG REWRITE command rewrites the redis.conf file the server was started with, applying the minimal changes needed to make it reflecting the configuration currently used by the server, that may be different compared to the original one because of the use of the CONFIG SET command.
         /// </summary>
-        /// <remarks>http://redis.io/commands/config-rewrite</remarks>
+        /// <remarks>https://redis.io/commands/config-rewrite</remarks>
         void ConfigRewrite(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The CONFIG REWRITE command rewrites the redis.conf file the server was started with, applying the minimal changes needed to make it reflecting the configuration currently used by the server, that may be different compared to the original one because of the use of the CONFIG SET command.
         /// </summary>
-        /// <remarks>http://redis.io/commands/config-rewrite</remarks>
+        /// <remarks>https://redis.io/commands/config-rewrite</remarks>
         Task ConfigRewriteAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The CONFIG SET command is used in order to reconfigure the server at runtime without the need to restart Redis. You can change both trivial parameters or switch from one to another persistence option using this command.
         /// </summary>
-        /// <remarks>http://redis.io/commands/config-set</remarks>
+        /// <remarks>https://redis.io/commands/config-set</remarks>
         void ConfigSet(RedisValue setting, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The CONFIG SET command is used in order to reconfigure the server at runtime without the need to restart Redis. You can change both trivial parameters or switch from one to another persistence option using this command.
         /// </summary>
-        /// <remarks>http://redis.io/commands/config-set</remarks>
+        /// <remarks>https://redis.io/commands/config-set</remarks>
         Task ConfigSetAsync(RedisValue setting, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the number of keys in the database.
         /// </summary>
-        /// <remarks>http://redis.io/commands/dbsize</remarks>
+        /// <remarks>https://redis.io/commands/dbsize</remarks>
         long DatabaseSize(int database = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the number of keys in the database.
         /// </summary>
-        /// <remarks>http://redis.io/commands/dbsize</remarks>
+        /// <remarks>https://redis.io/commands/dbsize</remarks>
         Task<long> DatabaseSizeAsync(int database = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the same message passed in
         /// </summary>
-        /// <remarks>http://redis.io/commands/echo</remarks>
+        /// <remarks>https://redis.io/commands/echo</remarks>
         RedisValue Echo(RedisValue message, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the same message passed in
         /// </summary>
-        /// <remarks>http://redis.io/commands/echo</remarks>
+        /// <remarks>https://redis.io/commands/echo</remarks>
         Task<RedisValue> EchoAsync(RedisValue message, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Delete all the keys of all databases on the server.
         /// </summary>
-        /// <remarks>http://redis.io/commands/flushall</remarks>
+        /// <remarks>https://redis.io/commands/flushall</remarks>
         void FlushAllDatabases(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Delete all the keys of all databases on the server.
         /// </summary>
-        /// <remarks>http://redis.io/commands/flushall</remarks>
+        /// <remarks>https://redis.io/commands/flushall</remarks>
         Task FlushAllDatabasesAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Delete all the keys of the database.
         /// </summary>
-        /// <remarks>http://redis.io/commands/flushdb</remarks>
+        /// <remarks>https://redis.io/commands/flushdb</remarks>
         void FlushDatabase(int database = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Delete all the keys of the database.
         /// </summary>
-        /// <remarks>http://redis.io/commands/flushdb</remarks>
+        /// <remarks>https://redis.io/commands/flushdb</remarks>
         Task FlushDatabaseAsync(int database = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -218,53 +218,53 @@ namespace StackExchange.Redis
         /// <summary>
         /// The INFO command returns information and statistics about the server in a format that is simple to parse by computers and easy to read by humans.
         /// </summary>
-        /// <remarks>http://redis.io/commands/info</remarks>
+        /// <remarks>https://redis.io/commands/info</remarks>
         IGrouping<string, KeyValuePair<string, string>>[] Info(RedisValue section = default(RedisValue), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The INFO command returns information and statistics about the server in a format that is simple to parse by computers and easy to read by humans.
         /// </summary>
-        /// <remarks>http://redis.io/commands/info</remarks>
+        /// <remarks>https://redis.io/commands/info</remarks>
         Task<IGrouping<string, KeyValuePair<string, string>>[]> InfoAsync(RedisValue section = default(RedisValue), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The INFO command returns information and statistics about the server in a format that is simple to parse by computers and easy to read by humans.
         /// </summary>
-        /// <remarks>http://redis.io/commands/info</remarks>
+        /// <remarks>https://redis.io/commands/info</remarks>
         string InfoRaw(RedisValue section = default(RedisValue), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The INFO command returns information and statistics about the server in a format that is simple to parse by computers and easy to read by humans.
         /// </summary>
-        /// <remarks>http://redis.io/commands/info</remarks>
+        /// <remarks>https://redis.io/commands/info</remarks>
         Task<string> InfoRawAsync(RedisValue section = default(RedisValue), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns all keys matching pattern; the KEYS or SCAN commands will be used based on the server capabilities.
         /// </summary>
         /// <remarks>Warning: consider KEYS as a command that should only be used in production environments with extreme care.</remarks>
-        /// <remarks>http://redis.io/commands/keys</remarks>
-        /// <remarks>http://redis.io/commands/scan</remarks>
+        /// <remarks>https://redis.io/commands/keys</remarks>
+        /// <remarks>https://redis.io/commands/scan</remarks>
         IEnumerable<RedisKey> Keys(int database, RedisValue pattern, int pageSize, CommandFlags flags);
 
         /// <summary>
         /// Returns all keys matching pattern; the KEYS or SCAN commands will be used based on the server capabilities; note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
         /// </summary>
         /// <remarks>Warning: consider KEYS as a command that should only be used in production environments with extreme care.</remarks>
-        /// <remarks>http://redis.io/commands/keys</remarks>
-        /// <remarks>http://redis.io/commands/scan</remarks>
+        /// <remarks>https://redis.io/commands/keys</remarks>
+        /// <remarks>https://redis.io/commands/scan</remarks>
         IEnumerable<RedisKey> Keys(int database = 0, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the time of the last DB save executed with success. A client may check if a BGSAVE command succeeded reading the LASTSAVE value, then issuing a BGSAVE command and checking at regular intervals every N seconds if LASTSAVE changed.
         /// </summary>
-        /// <remarks>http://redis.io/commands/lastsave</remarks>
+        /// <remarks>https://redis.io/commands/lastsave</remarks>
         DateTime LastSave(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the time of the last DB save executed with success. A client may check if a BGSAVE command succeeded reading the LASTSAVE value, then issuing a BGSAVE command and checking at regular intervals every N seconds if LASTSAVE changed.
         /// </summary>
-        /// <remarks>http://redis.io/commands/lastsave</remarks>
+        /// <remarks>https://redis.io/commands/lastsave</remarks>
         Task<DateTime> LastSaveAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -275,19 +275,19 @@ namespace StackExchange.Redis
         /// <summary>
         /// Explicitly request the database to persist the current state to disk
         /// </summary>
-        /// <remarks>http://redis.io/commands/bgrewriteaof</remarks>
-        /// <remarks>http://redis.io/commands/bgsave</remarks>
-        /// <remarks>http://redis.io/commands/save</remarks>
-        /// <remarks>http://redis.io/topics/persistence</remarks>
+        /// <remarks>https://redis.io/commands/bgrewriteaof</remarks>
+        /// <remarks>https://redis.io/commands/bgsave</remarks>
+        /// <remarks>https://redis.io/commands/save</remarks>
+        /// <remarks>https://redis.io/topics/persistence</remarks>
         void Save(SaveType type, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Explicitly request the database to persist the current state to disk
         /// </summary>
-        /// <remarks>http://redis.io/commands/bgrewriteaof</remarks>
-        /// <remarks>http://redis.io/commands/bgsave</remarks>
-        /// <remarks>http://redis.io/commands/save</remarks>
-        /// <remarks>http://redis.io/topics/persistence</remarks>
+        /// <remarks>https://redis.io/commands/bgrewriteaof</remarks>
+        /// <remarks>https://redis.io/commands/bgsave</remarks>
+        /// <remarks>https://redis.io/commands/save</remarks>
+        /// <remarks>https://redis.io/topics/persistence</remarks>
         Task SaveAsync(SaveType type, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -341,91 +341,91 @@ namespace StackExchange.Redis
         Task<LoadedLuaScript> ScriptLoadAsync(LuaScript script, CommandFlags flags = CommandFlags.None);
 
         /// <summary>Asks the redis server to shutdown, killing all connections. Please FULLY read the notes on the SHUTDOWN command.</summary>
-        /// <remarks>http://redis.io/commands/shutdown</remarks>
+        /// <remarks>https://redis.io/commands/shutdown</remarks>
         void Shutdown(ShutdownMode shutdownMode = ShutdownMode.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The SLAVEOF command can change the replication settings of a slave on the fly. If a Redis server is already acting as slave, specifying a null master will turn off the replication, turning the Redis server into a MASTER. Specifying a non-null master will make the server a slave of another server listening at the specified hostname and port.
         /// </summary>
-        /// <remarks>http://redis.io/commands/slaveof</remarks>
+        /// <remarks>https://redis.io/commands/slaveof</remarks>
         void SlaveOf(EndPoint master, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// The SLAVEOF command can change the replication settings of a slave on the fly. If a Redis server is already acting as slave, specifying a null master will turn off the replication, turning the Redis server into a MASTER. Specifying a non-null master will make the server a slave of another server listening at the specified hostname and port.
         /// </summary>
-        /// <remarks>http://redis.io/commands/slaveof</remarks>
+        /// <remarks>https://redis.io/commands/slaveof</remarks>
         Task SlaveOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// To read the slow log the SLOWLOG GET command is used, that returns every entry in the slow log. It is possible to return only the N most recent entries passing an additional argument to the command (for instance SLOWLOG GET 10).
         /// </summary>
-        /// <remarks>http://redis.io/commands/slowlog</remarks>
+        /// <remarks>https://redis.io/commands/slowlog</remarks>
         CommandTrace[] SlowlogGet(int count = 0, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// To read the slow log the SLOWLOG GET command is used, that returns every entry in the slow log. It is possible to return only the N most recent entries passing an additional argument to the command (for instance SLOWLOG GET 10).
         /// </summary>
-        /// <remarks>http://redis.io/commands/slowlog</remarks>
+        /// <remarks>https://redis.io/commands/slowlog</remarks>
         Task<CommandTrace[]> SlowlogGetAsync(int count = 0, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// You can reset the slow log using the SLOWLOG RESET command. Once deleted the information is lost forever.
         /// </summary>
-        /// <remarks>http://redis.io/commands/slowlog</remarks>
+        /// <remarks>https://redis.io/commands/slowlog</remarks>
         void SlowlogReset(CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// You can reset the slow log using the SLOWLOG RESET command. Once deleted the information is lost forever.
         /// </summary>
-        /// <remarks>http://redis.io/commands/slowlog</remarks>
+        /// <remarks>https://redis.io/commands/slowlog</remarks>
         Task SlowlogResetAsync(CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// Lists the currently active channels. An active channel is a Pub/Sub channel with one ore more subscribers (not including clients subscribed to patterns).
         /// </summary>
         /// <returns> a list of active channels, optionally matching the specified pattern.</returns>
-        /// <remarks>http://redis.io/commands/pubsub</remarks>
+        /// <remarks>https://redis.io/commands/pubsub</remarks>
         RedisChannel[] SubscriptionChannels(RedisChannel pattern = default(RedisChannel), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Lists the currently active channels. An active channel is a Pub/Sub channel with one ore more subscribers (not including clients subscribed to patterns).
         /// </summary>
         /// <returns> a list of active channels, optionally matching the specified pattern.</returns>
-        /// <remarks>http://redis.io/commands/pubsub</remarks>
+        /// <remarks>https://redis.io/commands/pubsub</remarks>
         Task<RedisChannel[]> SubscriptionChannelsAsync(RedisChannel pattern = default(RedisChannel), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the number of subscriptions to patterns (that are performed using the PSUBSCRIBE command). Note that this is not just the count of clients subscribed to patterns but the total number of patterns all the clients are subscribed to.
         /// </summary>
         /// <returns>the number of patterns all the clients are subscribed to.</returns>
-        /// <remarks>http://redis.io/commands/pubsub</remarks>
+        /// <remarks>https://redis.io/commands/pubsub</remarks>
         long SubscriptionPatternCount(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the number of subscriptions to patterns (that are performed using the PSUBSCRIBE command). Note that this is not just the count of clients subscribed to patterns but the total number of patterns all the clients are subscribed to.
         /// </summary>
         /// <returns>the number of patterns all the clients are subscribed to.</returns>
-        /// <remarks>http://redis.io/commands/pubsub</remarks>
+        /// <remarks>https://redis.io/commands/pubsub</remarks>
         Task<long> SubscriptionPatternCountAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the number of subscribers (not counting clients subscribed to patterns) for the specified channel.
         /// </summary>
-        /// <remarks>http://redis.io/commands/pubsub</remarks>
+        /// <remarks>https://redis.io/commands/pubsub</remarks>
         long SubscriptionSubscriberCount(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the number of subscribers (not counting clients subscribed to patterns) for the specified channel.
         /// </summary>
-        /// <remarks>http://redis.io/commands/pubsub</remarks>
+        /// <remarks>https://redis.io/commands/pubsub</remarks>
         Task<long> SubscriptionSubscriberCountAsync(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// The TIME command returns the current server time.
         /// </summary>
         /// <returns>The server's current time.</returns>
-        /// <remarks>http://redis.io/commands/time</remarks>
+        /// <remarks>https://redis.io/commands/time</remarks>
         DateTime Time(CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// The TIME command returns the current server time.
         /// </summary>
         /// <returns>The server's current time.</returns>
-        /// <remarks>http://redis.io/commands/time</remarks>
+        /// <remarks>https://redis.io/commands/time</remarks>
         Task<DateTime> TimeAsync(CommandFlags flags = CommandFlags.None);
 
         #region Sentinel
@@ -437,7 +437,7 @@ namespace StackExchange.Redis
         /// <param name="serviceName">the sentinel service name</param>
         /// <param name="flags"></param>
         /// <returns>the master ip and port</returns>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         EndPoint SentinelGetMasterAddressByName(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -447,7 +447,7 @@ namespace StackExchange.Redis
         /// <param name="serviceName">the sentinel service name</param>
         /// <param name="flags"></param>
         /// <returns>the master ip and port</returns>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         Task<EndPoint> SentinelGetMasterAddressByNameAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -456,7 +456,7 @@ namespace StackExchange.Redis
         /// <param name="serviceName">the sentinel service name</param>
         /// <param name="flags"></param>
         /// <returns>the master state as KeyValuePairs</returns>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         KeyValuePair<string, string>[] SentinelMaster(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -466,7 +466,7 @@ namespace StackExchange.Redis
         /// <param name="serviceName">the sentinel service name</param>
         /// <param name="flags"></param>
         /// <returns>the master state as KeyValuePairs</returns>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         Task<KeyValuePair<string, string>[]> SentinelMasterAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -474,7 +474,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="flags"></param>
         /// <returns>an array of master state KeyValuePair arrays</returns>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         KeyValuePair<string, string>[][] SentinelMasters(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -482,7 +482,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="flags"></param>
         /// <returns>an array of master state KeyValuePair arrays</returns>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         Task<KeyValuePair<string, string>[][]> SentinelMastersAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -491,7 +491,7 @@ namespace StackExchange.Redis
         /// <param name="serviceName">the sentinel service name</param>
         /// <param name="flags"></param>
         /// <returns>an array of slave state KeyValuePair arrays</returns>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         KeyValuePair<string, string>[][] SentinelSlaves(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -500,7 +500,7 @@ namespace StackExchange.Redis
         /// <param name="serviceName">the sentinel service name</param>
         /// <param name="flags"></param>
         /// <returns>an array of slave state KeyValuePair arrays</returns>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         Task<KeyValuePair<string, string>[][]> SentinelSlavesAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -509,7 +509,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="serviceName">the sentinel service name</param>
         /// <param name="flags"></param>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         void SentinelFailover(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -518,7 +518,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="serviceName">the sentinel service name</param>
         /// <param name="flags"></param>
-        /// <remarks>http://redis.io/topics/sentinel</remarks>
+        /// <remarks>https://redis.io/topics/sentinel</remarks>
         Task SentinelFailoverAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         #endregion

--- a/StackExchange.Redis/StackExchange/Redis/ISubscriber.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ISubscriber.cs
@@ -34,26 +34,26 @@ namespace StackExchange.Redis
         /// Posts a message to the given channel.
         /// </summary>
         /// <returns>the number of clients that received the message.</returns>
-        /// <remarks>http://redis.io/commands/publish</remarks>
+        /// <remarks>https://redis.io/commands/publish</remarks>
         long Publish(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// Posts a message to the given channel.
         /// </summary>
         /// <returns>the number of clients that received the message.</returns>
-        /// <remarks>http://redis.io/commands/publish</remarks>
+        /// <remarks>https://redis.io/commands/publish</remarks>
         Task<long> PublishAsync(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
         /// <summary>
         /// Subscribe to perform some operation when a change to the preferred/active node is broadcast.
         /// </summary>
-        /// <remarks>http://redis.io/commands/subscribe</remarks>
-        /// <remarks>http://redis.io/commands/psubscribe</remarks>
+        /// <remarks>https://redis.io/commands/subscribe</remarks>
+        /// <remarks>https://redis.io/commands/psubscribe</remarks>
         void Subscribe(RedisChannel channel, Action<RedisChannel, RedisValue> handler, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Subscribe to perform some operation when a change to the preferred/active node is broadcast.
         /// </summary>
-        /// <remarks>http://redis.io/commands/subscribe</remarks>
-        /// <remarks>http://redis.io/commands/psubscribe</remarks>
+        /// <remarks>https://redis.io/commands/subscribe</remarks>
+        /// <remarks>https://redis.io/commands/psubscribe</remarks>
         Task SubscribeAsync(RedisChannel channel, Action<RedisChannel, RedisValue> handler, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -68,22 +68,22 @@ namespace StackExchange.Redis
         /// of the subscribers; if a handler is specified, the subscription is only cancelled if this handler is the 
         /// last handler remaining against the channel
         /// </summary>
-        /// <remarks>http://redis.io/commands/unsubscribe</remarks>
-        /// <remarks>http://redis.io/commands/punsubscribe</remarks>
+        /// <remarks>https://redis.io/commands/unsubscribe</remarks>
+        /// <remarks>https://redis.io/commands/punsubscribe</remarks>
         void Unsubscribe(RedisChannel channel, Action<RedisChannel, RedisValue> handler = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Unsubscribe all subscriptions on this instance
         /// </summary>
-        /// <remarks>http://redis.io/commands/unsubscribe</remarks>
-        /// <remarks>http://redis.io/commands/punsubscribe</remarks>
+        /// <remarks>https://redis.io/commands/unsubscribe</remarks>
+        /// <remarks>https://redis.io/commands/punsubscribe</remarks>
         void UnsubscribeAll(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Unsubscribe all subscriptions on this instance
         /// </summary>
-        /// <remarks>http://redis.io/commands/unsubscribe</remarks>
-        /// <remarks>http://redis.io/commands/punsubscribe</remarks>
+        /// <remarks>https://redis.io/commands/unsubscribe</remarks>
+        /// <remarks>https://redis.io/commands/punsubscribe</remarks>
         Task UnsubscribeAllAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -91,8 +91,8 @@ namespace StackExchange.Redis
         /// of the subscribers; if a handler is specified, the subscription is only cancelled if this handler is the 
         /// last handler remaining against the channel
         /// </summary>
-        /// <remarks>http://redis.io/commands/unsubscribe</remarks>
-        /// <remarks>http://redis.io/commands/punsubscribe</remarks>
+        /// <remarks>https://redis.io/commands/unsubscribe</remarks>
+        /// <remarks>https://redis.io/commands/punsubscribe</remarks>
         Task UnsubscribeAsync(RedisChannel channel, Action<RedisChannel, RedisValue> handler = null, CommandFlags flags = CommandFlags.None);
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/ITransaction.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ITransaction.cs
@@ -10,7 +10,7 @@ namespace StackExchange.Redis
     /// aborted (DISCARD) or not applied in the first place (UNWATCH) until the responses from
     /// the constraint checks have arrived.
     /// </summary>
-    /// <remarks>http://redis.io/topics/transactions</remarks>
+    /// <remarks>https://redis.io/topics/transactions</remarks>
     /// <remarks>Note that on a cluster, it may be required that all keys involved in the transaction
     /// (including constraints) are in the same hash-slot</remarks>
     public interface ITransaction : IBatch

--- a/StackExchange.Redis/StackExchange/Redis/LuaScript.cs
+++ b/StackExchange.Redis/StackExchange/Redis/LuaScript.cs
@@ -11,7 +11,7 @@ namespace StackExchange.Redis
     /// Unlike normal Redis Lua scripts, LuaScript can have named parameters (prefixed by a @).
     /// Public fields and properties of the passed in object are treated as parameters.
     /// 
-    /// Parameters of type RedisKey are sent to Redis as KEY (http://redis.io/commands/eval) in addition to arguments, 
+    /// Parameters of type RedisKey are sent to Redis as KEY (https://redis.io/commands/eval) in addition to arguments, 
     /// so as to play nicely with Redis Cluster.
     /// 
     /// All members of this class are thread safe.
@@ -218,7 +218,7 @@ namespace StackExchange.Redis
     /// Unlike normal Redis Lua scripts, LoadedLuaScript can have named parameters (prefixed by a @).
     /// Public fields and properties of the passed in object are treated as parameters.
     /// 
-    /// Parameters of type RedisKey are sent to Redis as KEY (http://redis.io/commands/eval) in addition to arguments, 
+    /// Parameters of type RedisKey are sent to Redis as KEY (https://redis.io/commands/eval) in addition to arguments, 
     /// so as to play nicely with Redis Cluster.
     /// 
     /// All members of this class are thread safe.

--- a/StackExchange.Redis/StackExchange/Redis/RedisType.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisType.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// The intrinsinc data-types supported by redis
     /// </summary>
-    /// <remarks>http://redis.io/topics/data-types</remarks>
+    /// <remarks>https://redis.io/topics/data-types</remarks>
     public enum RedisType
     {
         /// <summary>
@@ -14,28 +14,28 @@
         /// Strings are the most basic kind of Redis value. Redis Strings are binary safe, this means that a Redis string can contain any kind of data, for instance a JPEG image or a serialized Ruby object.
         /// A String value can be at max 512 Megabytes in length.
         /// </summary>
-        /// <remarks>http://redis.io/commands#string</remarks>
+        /// <remarks>https://redis.io/commands#string</remarks>
         String,
         /// <summary>
         /// Redis Lists are simply lists of strings, sorted by insertion order. It is possible to add elements to a Redis List pushing new elements on the head (on the left) or on the tail (on the right) of the list.
         /// </summary>
-        /// <remarks>http://redis.io/commands#list</remarks>
+        /// <remarks>https://redis.io/commands#list</remarks>
         List,
         /// <summary>
         /// Redis Sets are an unordered collection of Strings. It is possible to add, remove, and test for existence of members in O(1) (constant time regardless of the number of elements contained inside the Set).
         /// Redis Sets have the desirable property of not allowing repeated members. Adding the same element multiple times will result in a set having a single copy of this element. Practically speaking this means that adding a member does not require a check if exists then add operation.
         /// </summary>
-        /// <remarks>http://redis.io/commands#set</remarks>
+        /// <remarks>https://redis.io/commands#set</remarks>
         Set,
         /// <summary>
         /// Redis Sorted Sets are, similarly to Redis Sets, non repeating collections of Strings. The difference is that every member of a Sorted Set is associated with score, that is used in order to take the sorted set ordered, from the smallest to the greatest score. While members are unique, scores may be repeated.
         /// </summary>
-        /// <remarks>http://redis.io/commands#sorted_set</remarks>
+        /// <remarks>https://redis.io/commands#sorted_set</remarks>
         SortedSet,
         /// <summary>
         /// Redis Hashes are maps between string fields and string values, so they are the perfect data type to represent objects (eg: A User with a number of fields like name, surname, age, and so forth)
         /// </summary>
-        /// <remarks>http://redis.io/commands#hash</remarks>
+        /// <remarks>https://redis.io/commands#hash</remarks>
         Hash,
         /// <summary>
         /// The data-type was not recognised by the client library

--- a/StackExchange.Redis/StackExchange/Redis/SaveType.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SaveType.cs
@@ -10,17 +10,17 @@ namespace StackExchange.Redis
         /// <summary>
         /// Instruct Redis to start an Append Only File rewrite process. The rewrite will create a small optimized version of the current Append Only File.
         /// </summary>
-        /// <remarks>http://redis.io/commands/bgrewriteaof</remarks>
+        /// <remarks>https://redis.io/commands/bgrewriteaof</remarks>
         BackgroundRewriteAppendOnlyFile,
         /// <summary>
         /// Save the DB in background. The OK code is immediately returned. Redis forks, the parent continues to serve the clients, the child saves the DB on disk then exits. A client my be able to check if the operation succeeded using the LASTSAVE command.
         /// </summary>
-        /// <remarks>http://redis.io/commands/bgsave</remarks>
+        /// <remarks>https://redis.io/commands/bgsave</remarks>
         BackgroundSave,
         /// <summary>
         /// Save the DB in foreground. This is almost never a good thing to do, and could cause significant blocking. Only do this if you know you need to save
         /// </summary>
-        /// <remarks>http://redis.io/commands/save</remarks>
+        /// <remarks>https://redis.io/commands/save</remarks>
         [Obsolete("Saving on the foreground can cause significant blocking; use with extreme caution")]
         ForegroundSave
     }

--- a/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
@@ -249,7 +249,7 @@ namespace StackExchange.Redis
         }
         internal void SetFastLoopbackOption(Socket socket)
         {
-            // SIO_LOOPBACK_FAST_PATH (http://msdn.microsoft.com/en-us/library/windows/desktop/jj841212%28v=vs.85%29.aspx)
+            // SIO_LOOPBACK_FAST_PATH (https://msdn.microsoft.com/en-us/library/windows/desktop/jj841212%28v=vs.85%29.aspx)
             // Speeds up localhost operations significantly. OK to apply to a socket that will not be hooked up to localhost, 
             // or will be subject to WFP filtering.
             const int SIO_LOOPBACK_FAST_PATH = -1744830448;

--- a/StackExchange.Redis/StackExchange/Redis/TaskSource.cs
+++ b/StackExchange.Redis/StackExchange/Redis/TaskSource.cs
@@ -10,7 +10,7 @@ namespace StackExchange.Redis
 {
     /// <summary>
     /// We want to prevent callers hijacking the reader thread; this is a bit nasty, but works;
-    /// see http://stackoverflow.com/a/22588431/23354 for more information; a huge
+    /// see https://stackoverflow.com/a/22588431/23354 for more information; a huge
     /// thanks to Eli Arbel for spotting this (even though it is pure evil; it is *my kind of evil*)
     /// </summary>
 #if DEBUG


### PR DESCRIPTION
Except for redisearch.io and www.ideawu.com, because they don't have an https endpoint atm.